### PR TITLE
fix: DEV-4081: Handle edge case related to CORS headers and AWS S3

### DIFF
--- a/e2e/tests/image.magic-wand.test.js
+++ b/e2e/tests/image.magic-wand.test.js
@@ -158,10 +158,9 @@ Scenario('Make sure the magic wand works in a variety of scenarios', async funct
   I.say('Unselecting last magic wand region');
   I.pressKey('Escape');
 
-  // @todo currently gallery doesn't work well with CORS, so this is not covered by test
   // Change to the false color view, zoom in, and magic wand with a new class.
-  // I.say('Changing to false-color view');
-  // I.click('[class*="gallery--"] img[src*="false_color"]');
+  I.say('Changing to false-color view');
+  I.click('[class*="gallery--"] img[src*="false_color"]');
 
   I.say('Zooming in');
   I.click('button[aria-label="zoom-in"]');

--- a/src/tags/object/Image.js
+++ b/src/tags/object/Image.js
@@ -34,22 +34,22 @@ import { FF_DEV_3377, FF_DEV_3666, FF_DEV_4081, isFF } from '../../utils/feature
  * @name Image
  * @meta_title Image Tags for Images
  * @meta_description Customize Label Studio with the Image tag to annotate images for computer vision machine learning and data science projects.
- * @param {string} name                       - Name of the element
- * @param {string} value                      - Data field containing a path or URL to the image
- * @param {boolean} [smoothing]               - Enable smoothing, by default it uses user settings
- * @param {string=} [width=100%]              - Image width
- * @param {string=} [maxWidth=750px]          - Maximum image width
- * @param {boolean=} [zoom=false]             - Enable zooming an image with the mouse wheel
- * @param {boolean=} [negativeZoom=false]     - Enable zooming out an image
- * @param {float=} [zoomBy=1.1]               - Scale factor
- * @param {boolean=} [grid=false]             - Whether to show a grid
- * @param {number=} [gridSize=30]             - Specify size of the grid
- * @param {string=} [gridColor="#EEEEF4"]     - Color of the grid in hex, opacity is 0.15
- * @param {boolean} [zoomControl=false]       - Show zoom controls in toolbar
- * @param {boolean} [brightnessControl=false] - Show brightness control in toolbar
- * @param {boolean} [contrastControl=false]   - Show contrast control in toolbar
- * @param {boolean} [rotateControl=false]     - Show rotate control in toolbar
- * @param {boolean} [crosshair=false]         - Show crosshair cursor
+ * @param {string} name                         - Name of the element
+ * @param {string} value                        - Data field containing a path or URL to the image
+ * @param {boolean} [smoothing]                 - Enable smoothing, by default it uses user settings
+ * @param {string=} [width=100%]                - Image width
+ * @param {string=} [maxWidth=750px]            - Maximum image width
+ * @param {boolean=} [zoom=false]               - Enable zooming an image with the mouse wheel
+ * @param {boolean=} [negativeZoom=false]       - Enable zooming out an image
+ * @param {float=} [zoomBy=1.1]                 - Scale factor
+ * @param {boolean=} [grid=false]               - Whether to show a grid
+ * @param {number=} [gridSize=30]               - Specify size of the grid
+ * @param {string=} [gridColor="#EEEEF4"]       - Color of the grid in hex, opacity is 0.15
+ * @param {boolean} [zoomControl=false]         - Show zoom controls in toolbar
+ * @param {boolean} [brightnessControl=false]   - Show brightness control in toolbar
+ * @param {boolean} [contrastControl=false]     - Show contrast control in toolbar
+ * @param {boolean} [rotateControl=false]       - Show rotate control in toolbar
+ * @param {boolean} [crosshair=false]           - Show crosshair cursor
  * @param {string} [horizontalAlignment="left"] - Where to align image horizontally. Can be one of "left", "center" or "right"
  * @param {string} [verticalAlignment="top"]    - Where to align image vertically. Can be one of "top", "center" or "bottom"
  * @param {string} [defaultZoom="fit"]          - Specify the initial zoom of the image within the viewport while preserving it’s ratio. Can be one of "auto", "original" or "fit"

--- a/src/tags/object/Image.js
+++ b/src/tags/object/Image.js
@@ -286,8 +286,6 @@ const Model = types.model({
   stageZoomX: 1,
   stageZoomY: 1,
   currentZoom: 1,
-
-  ts: Date.now(),
 })).views(self => ({
   get store() {
     return getRoot(self);
@@ -311,8 +309,7 @@ const Model = types.model({
       // Details: https://bugs.chromium.org/p/chromium/issues/detail?id=409090
       // Fix is to break the cache for this image only if its cross origin and on
       // S3.
-      value = `${value}?ts=${self.ts}`;
-      return value;
+      return value + '?v=1';
     } else {
       return value;
     }

--- a/src/tags/object/Image.js
+++ b/src/tags/object/Image.js
@@ -303,12 +303,14 @@ const Model = types.model({
 
     if (!self.imageCrossOrigin) {
       return value;
-    } else if (isFF(FF_DEV_4081) && /^https?:.*?s3\.amazonaws\.com\//g.test(value)){
-      // AWS S3 inconsistently sends back the Origin HTTP header, between images in an <img>
-      // tag and a JavaScript CORS request, breaking cross domain images.
+    } else if (isFF(FF_DEV_4081) &&
+               /^https?:.*?s3\.amazonaws\.com\//g.test(value) &&
+               !(new URL(value)).searchParams.has('X-Amz-Signature')) {
+      // Unsigned AWS S3 inconsistently sends back the Origin HTTP header, between
+      // images in an <img> tag and a JavaScript CORS request, breaking cross domain images.
       // Details: https://bugs.chromium.org/p/chromium/issues/detail?id=409090
-      // Fix is to break the cache for this image only if its cross origin and on
-      // S3.
+      // Fix is to break the cache for this image only if its cross origin, on
+      // S3, and not a signed AWS URL with X-Amz-Signature in its query params.
       return value + '?v=1';
     } else {
       return value;


### PR DESCRIPTION
### PR fulfills these requirements
- [*] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [*] Tests for the changes have been added/updated (for bug fixes/features)
- [*] Docs have been added/updated (for bug fixes/features)
- [*] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [*] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [*] Frontend



### Describe the reason for change
_(link to issue, supportive screenshots etc.)_

#### What does this fix?
_(if this is a bug fix)_

AWS S3's CORS headers have a bug where if an image is requested in an S3 bucket initially from an HTML `<img>` tag the HTTP response incorrectly leaves out the HTTP `Origin` header. Then, later on, if a JavaScript CORS request is made to this same image, Chrome will return the cached request without the `Origin` header, which means the CORS request will fail. This issue is described here: https://bugs.chromium.org/p/chromium/issues/detail?id=409090

The user facing impact of this bug is that if there is a gallery of multiple images to be labelled beneath the stage, the thumbnails will be shown correctly, but once you click into them you get a CORS error shown on the stage.

The fix is as follows: If the Magic Wand feature flag is on AND if the Label Studio Image tag has the `crossOrigin` attribute set AND if the src image is an AWS S3 bucket, then we do a trick to break the cache for the image by adding a `?v=1` timestap on it.



#### What is the new behavior?
_(if this is a breaking or feature change)_



#### What is the current behavior?
_(if this is a breaking or feature change)_



#### What libraries were added/updated?
_(list all with version changes)_



#### Does this change affect performance?
_(if so describe the impacts positive or negative)_

Breaking the image cache can potentially affect image loading performance. We break the image cache as focused as possible (only for magic wand feature flag, only when using crossOrigin attribute, and only for AWS S3 URLs). In addition, we make sure that we are storing the timestamp as a volatile value on the Image object, so that we don't mindlessly keep breaking the cache with a new timestamp each time React might redraw the screen. We only need to break the cache on the initial image load.

#### Does this change affect security?
_(if so describe the impacts positive or negative)_



#### What alternative approaches were there?
_(briefly list any if applicable)_

Unfortunately there are no other known workarounds to this AWS S3 issue - Amazon should fix the bug on their side, but it sounds like they've dropped the ball. This does not effect other cloud bucket providers, such as GCP.

#### What feature flags were used to cover this change?
_(briefly list any if applicable)_

The Magic Wand feature flag: `FF_DEV_4081 = 'fflag_feat_front_dev_4081_magic_wand_tool'`

### Does this PR introduce a breaking change?
_(check only one)_
- [*] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [ ] No
- [ ] Not sure (briefly explain the situation below)



### What level of testing was included in the change?
_(check all that apply)_
- [*] e2e
- [ ] integration
- [ ] unit



### Which logical domain(s) does this change affect?
_(for bug fixes/features, be as precise as possible. ex. Authentication, Annotation History, Review Stream etc.)_

Image segmentation labelling and Image gallery if multiple images are present to be labelled