### PR TITLE
fix: LSDV-5177: Fix storing Image regions in history

### DIFF
--- a/src/regions/EllipseRegion.js
+++ b/src/regions/EllipseRegion.js
@@ -15,7 +15,7 @@ import { AreaMixin } from '../mixins/AreaMixin';
 import { KonvaRegionMixin } from '../mixins/KonvaRegion';
 import { ImageModel } from '../tags/object/Image';
 import { rotateBboxCoords } from '../utils/bboxCoords';
-import { FF_DEV_3793, isFF } from '../utils/feature-flags';
+import { FF_DEV_3793, FF_LSDV_5177, isFF } from '../utils/feature-flags';
 import { createDragBoundFunc } from '../utils/image';
 import { AliveRegion } from './AliveRegion';
 import { EditableRegion } from './EditableRegion';
@@ -23,14 +23,28 @@ import { EditableRegion } from './EditableRegion';
 const EllipseRegionAbsoluteCoordsDEV3793 = types
   .model({
     coordstype: types.optional(types.enumeration(['px', 'perc']), 'perc'),
+    ...(isFF(FF_LSDV_5177)?
+      {
+        relativeX: 0,
+        relativeY: 0,
+        relativeWidth: 0,
+        relativeHeight: 0,
+        relativeRadiusX: 0,
+        relativeRadiusY: 0,
+      }:{}
+    ),
   })
   .volatile(() => ({
-    relativeX: 0,
-    relativeY: 0,
-    relativeWidth: 0,
-    relativeHeight: 0,
-    relativeRadiusX: 0,
-    relativeRadiusY: 0,
+    ...(!isFF(FF_LSDV_5177)?
+      {
+        relativeX: 0,
+        relativeY: 0,
+        relativeWidth: 0,
+        relativeHeight: 0,
+        relativeRadiusX: 0,
+        relativeRadiusY: 0,
+      }:{}
+    ),
   }))
   .actions(self => ({
     afterCreate() {

--- a/src/regions/KeyPointRegion.js
+++ b/src/regions/KeyPointRegion.js
@@ -13,7 +13,7 @@ import { useRegionStyles } from '../hooks/useRegionColor';
 import { AreaMixin } from '../mixins/AreaMixin';
 import { KonvaRegionMixin } from '../mixins/KonvaRegion';
 import { ImageModel } from '../tags/object/Image';
-import { FF_DEV_3793, isFF } from '../utils/feature-flags';
+import { FF_DEV_3793, FF_LSDV_5177, isFF } from '../utils/feature-flags';
 import { createDragBoundFunc } from '../utils/image';
 import { AliveRegion } from './AliveRegion';
 import { EditableRegion } from './EditableRegion';
@@ -21,10 +21,16 @@ import { EditableRegion } from './EditableRegion';
 const KeyPointRegionAbsoluteCoordsDEV3793 = types
   .model({
     coordstype: types.optional(types.enumeration(['px', 'perc']), 'perc'),
+    ...(isFF(FF_LSDV_5177)?{
+      relativeX: 0,
+      relativeY: 0,
+    }:{}),
   })
   .volatile(() => ({
-    relativeX: 0,
-    relativeY: 0,
+    ...(!isFF(FF_LSDV_5177)?{
+      relativeX: 0,
+      relativeY: 0,
+    }:{}),
   }))
   .actions(self => ({
     afterCreate() {

--- a/src/regions/PolygonPoint.js
+++ b/src/regions/PolygonPoint.js
@@ -5,15 +5,22 @@ import { getParent, getRoot, hasParent, types } from 'mobx-state-tree';
 
 import { guidGenerator } from '../core/Helpers';
 import { useRegionStyles } from '../hooks/useRegionColor';
-import { FF_DEV_2431, FF_DEV_3793, isFF } from '../utils/feature-flags';
+import { FF_DEV_2431, FF_DEV_3793, FF_LSDV_5177, isFF } from '../utils/feature-flags';
 
-const PolygonPointAbsoluteCoordsDEV3793 = types.model()
-  .volatile(() => ({
+const PolygonPointAbsoluteCoordsDEV3793 = types.model(
+  isFF(FF_LSDV_5177) ? {
     relativeX: 0,
     relativeY: 0,
     initX: 0,
     initY: 0,
-  }))
+  } : {},
+)
+  .volatile(() => (!isFF(FF_LSDV_5177) ? {
+    relativeX: 0,
+    relativeY: 0,
+    initX: 0,
+    initY: 0,
+  } : {}))
   .actions(self => ({
     afterCreate() {
       self.initX = self.x;

--- a/src/regions/RectRegion.js
+++ b/src/regions/RectRegion.js
@@ -13,7 +13,7 @@ import NormalizationMixin from '../mixins/Normalization';
 import RegionsMixin from '../mixins/Regions';
 import { ImageModel } from '../tags/object/Image';
 import { rotateBboxCoords } from '../utils/bboxCoords';
-import { FF_DEV_3793, isFF } from '../utils/feature-flags';
+import { FF_DEV_3793, FF_LSDV_5177, isFF } from '../utils/feature-flags';
 import { createDragBoundFunc } from '../utils/image';
 import { AliveRegion } from './AliveRegion';
 import { EditableRegion } from './EditableRegion';
@@ -22,17 +22,24 @@ import { RegionWrapper } from './RegionWrapper';
 const RectRegionAbsoluteCoordsDEV3793 = types
   .model({
     coordstype: types.optional(types.enumeration(['px', 'perc']), 'perc'),
+    ...(isFF(FF_LSDV_5177) ? {
+      relativeX: 0,
+      relativeY: 0,
+
+      relativeWidth: 0,
+      relativeHeight: 0,
+    } : {}),
   })
-  .volatile(() => ({
+  .volatile(() => (!isFF(FF_LSDV_5177) ? {
     relativeX: 0,
     relativeY: 0,
 
     relativeWidth: 0,
     relativeHeight: 0,
-  }))
+  } : {}))
   .actions(self => ({
     afterCreate() {
-      switch (self.coordstype)  {
+      switch (self.coordstype) {
         case 'perc': {
           self.relativeX = self.x;
           self.relativeY = self.y;
@@ -405,7 +412,10 @@ const HtxRectangleView = ({ item }) => {
       item.notifyDrawingFinished();
     };
 
-    eventHandlers.dragBoundFunc = createDragBoundFunc(item, { x: item.x - item.bboxCoords.left, y: item.y - item.bboxCoords.top });
+    eventHandlers.dragBoundFunc = createDragBoundFunc(item, {
+      x: item.x - item.bboxCoords.left,
+      y: item.y - item.bboxCoords.top,
+    });
   }
 
   return (

--- a/src/utils/feature-flags.ts
+++ b/src/utils/feature-flags.ts
@@ -254,6 +254,12 @@ export const FF_LSDV_4998 = 'fflag_fix_front_lsdv_4998_missed_dynamic_children_0
  */
 export const FF_PROD_309 = 'fflag_feat_front_prod_309_choice_hint_080523_short';
 
+/**
+ * Fix storing Image regions in history
+ * @see: fflag_fix_front_dev_3793_relative_coords_short: Solves this problem in better way and is preferable than the current one
+ */
+export const FF_LSDV_5177 = 'fflag_fix_front_lsdv_5177_image_regions_in_history_260523_short';
+
 Object.assign(window, {
   APP_SETTINGS: {
     ...(window.APP_SETTINGS ?? {}),

--- a/tests/functional/data/image_segmentation/switch-annotation-regression.ts
+++ b/tests/functional/data/image_segmentation/switch-annotation-regression.ts
@@ -1,0 +1,95 @@
+export const fourToolsConfig = `
+  <View>
+    <Image name="img" value="$image"></Image>
+    <Rectangle name="r" toName="img"/>
+    <Ellipse name="e" toName="img"/>
+    <Polygon name="p" toName="img"/>
+    <KeyPoint name="k" toName="img"/>
+  </View>
+`;
+
+export const simpleImageData = {
+  image: 'https://htx-misc.s3.amazonaws.com/opensource/label-studio/examples/images/nick-owuor-astro-nic-visuals-wDifg5xc9Z4-unsplash.jpg',
+};
+
+export const fourToolsResult = [
+  {
+    'original_width': 2242,
+    'original_height': 2802,
+    'image_rotation': 0,
+    'value': {
+      'x': 4.070796460176991,
+      'y': 4.2492917847025495,
+      'width': 9.026548672566372,
+      'height': 9.206798866855522,
+      'rotation': 0,
+    },
+    'id': 'wFL6nEJpmv',
+    'from_name': 'r',
+    'to_name': 'img',
+    'type': 'rectangle',
+    'origin': 'manual',
+  },
+  {
+    'original_width': 2242,
+    'original_height': 2802,
+    'image_rotation': 0,
+    'value': {
+      'x': 21.946902654867255,
+      'y': 8.498583569405099,
+      'radiusX': 4.778761061946903,
+      'radiusY': 4.2492917847025495,
+      'rotation': 0,
+    },
+    'id': 'bQktnc3uW2',
+    'from_name': 'e',
+    'to_name': 'img',
+    'type': 'ellipse',
+    'origin': 'manual',
+  },
+  {
+    'original_width': 2242,
+    'original_height': 2802,
+    'image_rotation': 0,
+    'value': {
+      'points': [
+        [
+          5.132743362831858,
+          16.71388101983003,
+        ],
+        [
+          12.389380530973451,
+          16.71388101983003,
+        ],
+        [
+          11.327433628318584,
+          22.662889518413603,
+        ],
+        [
+          4.601769911504425,
+          19.971671388101978,
+        ],
+      ],
+    },
+    'id': 'NnZXqAu2em',
+    'from_name': 'p',
+    'to_name': 'img',
+    'type': 'polygon',
+    'origin': 'manual',
+  },
+  {
+    'original_width': 2242,
+    'original_height': 2802,
+    'image_rotation': 0,
+    'value': {
+      'x': 22.300884955752213,
+      'y': 18.838526912181305,
+      'width': 0.35398230088495575,
+    },
+    'id': 'Cq_T933Efd',
+    'from_name': 'k',
+    'to_name': 'img',
+    'type': 'keypoint',
+    'origin': 'manual',
+  },
+];

--- a/tests/functional/package.json
+++ b/tests/functional/package.json
@@ -18,7 +18,7 @@
     "cvg:summary": "nyc report --temp-dir=.nyc_output --reporter=text-summary --cwd=. --exclude-after-remap false"
   },
   "dependencies": {
-    "@heartexlabs/ls-test": "git+ssh://git@github.com/heartexlabs/ls-frontend-test#a0e92fc"
+    "@heartexlabs/ls-test": "git+ssh://git@github.com/heartexlabs/ls-frontend-test#bbbcfd3"
   },
   "devDependencies": {
     "ts-loader": "^9.4.2",

--- a/tests/functional/package.json
+++ b/tests/functional/package.json
@@ -18,7 +18,7 @@
     "cvg:summary": "nyc report --temp-dir=.nyc_output --reporter=text-summary --cwd=. --exclude-after-remap false"
   },
   "dependencies": {
-    "@heartexlabs/ls-test": "git+ssh://git@github.com/heartexlabs/ls-frontend-test#bbbcfd3"
+    "@heartexlabs/ls-test": "git+ssh://git@github.com/heartexlabs/ls-frontend-test#31b2ae7"
   },
   "devDependencies": {
     "ts-loader": "^9.4.2",

--- a/tests/functional/specs/image_segmentation/switch-annotation-regression.cy.ts
+++ b/tests/functional/specs/image_segmentation/switch-annotation-regression.cy.ts
@@ -1,0 +1,57 @@
+import { ImageView, LabelStudio, Sidebar } from '@heartexlabs/ls-test/helpers/LSF';
+import { FF_DEV_3873, FF_LSDV_5177 } from '../../../../src/utils/feature-flags';
+import {
+  fourToolsConfig,
+  fourToolsResult,
+  simpleImageData
+} from '../../data/image_segmentation/switch-annotation-regression';
+
+const resizeObserverLoopErrRe = /ResizeObserver loop limit exceeded/;
+
+Cypress.on('uncaught:exception', (err) => {
+  /* returning false here prevents Cypress from failing the test */
+  if (resizeObserverLoopErrRe.test(err.message)) {
+    return false;
+  }
+});
+
+describe('Image regions on switching annotations', () => {
+  it('Should keep position from selected history step', () => {
+    LabelStudio.addFeatureFlagsOnPageLoad({
+      [FF_DEV_3873]: true,
+      [FF_LSDV_5177]: true,
+    });
+
+    LabelStudio.params()
+      .config(fourToolsConfig)
+      .data(simpleImageData)
+      .withResult([])
+      .withResult(fourToolsResult)
+      .init();
+
+    Sidebar.hasRegions(4);
+    ImageView.waitForImage();
+
+    cy.log('Select all regions');
+    cy.get('[aria-label="move-tool"]').click();
+    ImageView.drawRect(5, 5, 300, 300);
+
+    cy.log('Move all regions to the borrom-right corner');
+    ImageView.drawRect(50, 50, 300, 500);
+    //There is some problem with releasing mouse in this scenario...
+    cy.get('body').type('{esc}');
+    cy.get('[aria-label="Undo"]').click();
+    cy.get('[aria-label="Undo"]').click();
+    cy.get('.lsf-annotation-button:nth-child(2)').click();
+    cy.get('.lsf-annotation-button:nth-child(1)').click();
+
+    LabelStudio.serialize().then(result => {
+      JSON.parse(JSON.stringify(result, (key, value) => {
+        if (Number.isFinite(value) && (key === 'x' || key === 'y' || key === '0' || key === '1')) {
+          expect(value).to.be.lessThan(400);
+        }
+        return value;
+      }));
+    });
+  });
+});

--- a/tests/functional/yarn.lock
+++ b/tests/functional/yarn.lock
@@ -264,9 +264,9 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
 
-"@heartexlabs/ls-test@git+ssh://git@github.com/heartexlabs/ls-frontend-test#a0e92fc":
+"@heartexlabs/ls-test@git+ssh://git@github.com/heartexlabs/ls-frontend-test#31b2ae7":
   version "1.0.8"
-  resolved "git+ssh://git@github.com/heartexlabs/ls-frontend-test#a0e92fcfe882e7e6e5aefad2ea9e3a2091ffccf0"
+  resolved "git+ssh://git@github.com/heartexlabs/ls-frontend-test#31b2ae7f09d08b9c021e208e575921a8fa72caee"
   dependencies:
     "@cypress/code-coverage" "^3.10.0"
     "@cypress/webpack-preprocessor" "^5.17.0"

--- a/tests/functional/yarn.lock
+++ b/tests/functional/yarn.lock
@@ -264,9 +264,9 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
 
-"@heartexlabs/ls-test@git+ssh://git@github.com/heartexlabs/ls-frontend-test#8296943":
+"@heartexlabs/ls-test@git+ssh://git@github.com/heartexlabs/ls-frontend-test#a0e92fc":
   version "1.0.8"
-  resolved "git+ssh://git@github.com/heartexlabs/ls-frontend-test#8296943a76de0fa35e48ed05236b50e9df2ce3d1"
+  resolved "git+ssh://git@github.com/heartexlabs/ls-frontend-test#a0e92fcfe882e7e6e5aefad2ea9e3a2091ffccf0"
   dependencies:
     "@cypress/code-coverage" "^3.10.0"
     "@cypress/webpack-preprocessor" "^5.17.0"
@@ -284,9 +284,9 @@
     webpack-cli "^5.0.1"
     yargs "^17.7.1"
 
-"@heartexlabs/ls-test@git+ssh://git@github.com/heartexlabs/ls-frontend-test#a0e92fc":
+"@heartexlabs/ls-test@git+ssh://git@github.com/heartexlabs/ls-frontend-test#bbbcfd3":
   version "1.0.8"
-  resolved "git+ssh://git@github.com/heartexlabs/ls-frontend-test#a0e92fcfe882e7e6e5aefad2ea9e3a2091ffccf0"
+  resolved "git+ssh://git@github.com/heartexlabs/ls-frontend-test#bbbcfd364287f637445667facd3f08da377de9a4"
   dependencies:
     "@cypress/code-coverage" "^3.10.0"
     "@cypress/webpack-preprocessor" "^5.17.0"


### PR DESCRIPTION
### PR fulfills these requirements
- [x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [x] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [x] Frontend



### Describe the reason for change
Regions with relative coordinates are drawing at unexpected places on switching annotations if there was not the last step of history for current annotation.

#### What feature flags were used to cover this change?
`fflag_fix_front_lsdv_5177_image_regions_in_history_260523_short`



### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [x] No
- [ ] Not sure (briefly explain the situation below)



### What level of testing was included in the change?
_(check all that apply)_
- [ ] e2e
- [x] integration
- [ ] unit



### Which logical domain(s) does this change affect?
`TimeTraveler`, `ImageView`
