### PR TITLE
fix: LEAP-14: Fixes for New Taxonomy

### DIFF
--- a/src/components/NewTaxonomy/NewTaxonomy.tsx
+++ b/src/components/NewTaxonomy/NewTaxonomy.tsx
@@ -50,6 +50,7 @@ const convert = (items: TaxonomyItem[], options: TaxonomyOptions): AntTaxonomyIt
     value: item.path.join(options.pathSeparator),
     key: item.path.join(options.pathSeparator),
     isLeaf: item.isLeaf !== false && !item.children,
+    disableCheckbox: options.leafsOnly && (item.isLeaf === false || !!item.children),
     children: item.children ? convert(item.children, options) : undefined,
   }));
 };

--- a/src/components/NewTaxonomy/NewTaxonomy.tsx
+++ b/src/components/NewTaxonomy/NewTaxonomy.tsx
@@ -44,13 +44,13 @@ type TaxonomyProps = {
   isEditable?: boolean,
 };
 
-const convert = (items: TaxonomyItem[], separator: string): AntTaxonomyItem[] => {
+const convert = (items: TaxonomyItem[], options: TaxonomyOptions): AntTaxonomyItem[] => {
   return items.map(item => ({
     title: item.label,
-    value: item.path.join(separator),
-    key: item.path.join(separator),
+    value: item.path.join(options.pathSeparator),
+    key: item.path.join(options.pathSeparator),
     isLeaf: item.isLeaf !== false && !item.children,
-    children: item.children ? convert(item.children, separator) : undefined,
+    children: item.children ? convert(item.children, options) : undefined,
   }));
 };
 
@@ -71,7 +71,7 @@ const NewTaxonomy = ({
   const style = { minWidth: options.minWidth ?? 200, maxWidth: options.maxWidth };
 
   useEffect(() => {
-    setTreeData(convert(items, separator));
+    setTreeData(convert(items, options));
   }, [items]);
 
   const loadData = useCallback(async (node: any) => {

--- a/src/tags/control/Taxonomy/Taxonomy.js
+++ b/src/tags/control/Taxonomy/Taxonomy.js
@@ -57,7 +57,7 @@ import styles from './Taxonomy.styl';
  * @param {string} [apiUrl]               - URL to fetch taxonomy from remote source; API should accept optional array `path` param: `apiUrl?path[]=root&path[]=child1` to return only nested children of `child1` node[^FF_TAXONOMY_ASYNC]
  * @param {boolean} [leafsOnly=false]     - Allow annotators to select only leaf nodes of taxonomy
  * @param {boolean} [showFullPath=false]  - Whether to show the full path of selected items
- * @param {string} [pathSeparator= / ]    - Separator to show in the full path
+ * @param {string} [pathSeparator=" / "]  - Separator to show in the full path
  * @param {number} [maxUsages]            - Maximum number of times a choice can be selected per task
  * @param {number} [maxWidth]             - Maximum width for dropdown
  * @param {number} [minWidth]             - Minimum width for dropdown

--- a/src/tags/control/Taxonomy/Taxonomy.js
+++ b/src/tags/control/Taxonomy/Taxonomy.js
@@ -132,6 +132,8 @@ const TaxonomyLabelingResult = types
         return self.annotation.results.find(r => r.from_name === self);
       }
 
+      // per-region Taxonomy and Taxonomy as a labeling tool share the same way to find a result,
+      // they just display items for current region, attached directly or in result.
       const area = self.annotation.highlightedNode;
 
       if (!area) return null;

--- a/src/tags/control/Taxonomy/Taxonomy.js
+++ b/src/tags/control/Taxonomy/Taxonomy.js
@@ -307,7 +307,9 @@ const Model = types
 
       try {
         const res = yield fetch(url);
-        const data = yield res.json();
+        const dataRaw = yield res.json();
+        // @todo temporary to support deprecated API response format (just array, no items)
+        const data = dataRaw.items ?? dataRaw;
         const prefix = path ?? [];
         // @todo use aliases
         // const items = data.map(({ alias, isLeaf, value }) => ({ label: value, path: [...prefix, alias ?? value], depth: 0, isLeaf }));

--- a/src/tags/control/Taxonomy/Taxonomy.js
+++ b/src/tags/control/Taxonomy/Taxonomy.js
@@ -57,7 +57,7 @@ import styles from './Taxonomy.styl';
  * @param {string} [apiUrl]               - URL to fetch taxonomy from remote source; API should accept optional array `path` param: `apiUrl?path[]=root&path[]=child1` to return only nested children of `child1` node[^FF_TAXONOMY_ASYNC]
  * @param {boolean} [leafsOnly=false]     - Allow annotators to select only leaf nodes of taxonomy
  * @param {boolean} [showFullPath=false]  - Whether to show the full path of selected items
- * @param {string} [pathSeparator=" / "]  - Separator to show in the full path
+ * @param {string} [pathSeparator= / ]    - Separator to show in the full path (default is " / ")
  * @param {number} [maxUsages]            - Maximum number of times a choice can be selected per task
  * @param {number} [maxWidth]             - Maximum width for dropdown
  * @param {number} [minWidth]             - Minimum width for dropdown

--- a/src/tags/control/Taxonomy/Taxonomy.js
+++ b/src/tags/control/Taxonomy/Taxonomy.js
@@ -293,7 +293,10 @@ const Model = types
       if (path) {
         for (const level of path) {
           item = item.children?.find(ch => ch.path.at(-1) === level);
-          if (!item) return;
+          if (!item) {
+            self.loading = false;
+            return;
+          }
         }
       }
 

--- a/src/tags/control/Taxonomy/Taxonomy.js
+++ b/src/tags/control/Taxonomy/Taxonomy.js
@@ -125,7 +125,7 @@ const TaxonomyLabelingResult = types
   .views(self => ({
     get result() {
       // @todo make it without duplication of ClassificationBase code
-      if (!self.isLabeling) {
+      if (!self.isLabeling && !self.perregion) {
         if (self.peritem) {
           return self._perItemResult;
         }
@@ -362,7 +362,7 @@ const Model = types
     },
 
     unselectAll() {
-      if (isFF(FF_TAXONOMY_LABELING)) self.selected = [];
+      if (isFF(FF_TAXONOMY_LABELING) && self.isLabeling) self.selected = [];
     },
 
     onAddLabel(path) {


### PR DESCRIPTION
- submitted values displayed after load with 5452 FF on
- per-region values are displayed with 5452 FF on
- fix API root item: object with `items` instead of plain array of items
- support `leafsOnly` param

### PR fulfills these requirements
- [x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



### Describe the reason for change
Critical issues





#### What feature flags were used to cover this change?
Problems appeared only with `fflag_feat_front_lsdv_5452_taxonomy_labeling_110823_short` on



### Does this PR introduce a breaking change?
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [x] No
- [ ] Not sure (briefly explain the situation below)



### What level of testing was included in the change?
_(check all that apply)_
- [ ] e2e
- [ ] integration
- [ ] unit



### Which logical domain(s) does this change affect?
Async Taxonomy, Taxonomy Labeling
