### PR TITLE
fix: LSDV-5544: Fix RichText tag in non-Chromium browsers

### DIFF
--- a/src/tags/object/RichText/domManager.ts
+++ b/src/tags/object/RichText/domManager.ts
@@ -667,7 +667,6 @@ export default class DomManager {
     const text = String(selection);
 
     selection.removeAllRanges();
-    selection.removeRange(range);
 
     // restore previous selection
     for (const range of lastRanges) {

--- a/tests/functional/package.json
+++ b/tests/functional/package.json
@@ -18,7 +18,7 @@
     "cvg:summary": "nyc report --temp-dir=.nyc_output --reporter=text-summary --cwd=. --exclude-after-remap false"
   },
   "dependencies": {
-    "@heartexlabs/ls-test": "git+ssh://git@github.com/heartexlabs/ls-frontend-test#579c0060d388a7a49f896a3b71373be45782ea6a"
+    "@heartexlabs/ls-test": "git+ssh://git@github.com/heartexlabs/ls-frontend-test#c5b8083cbaf25d279e5d4da7c1a4a7f8ebf1eb7b"
   },
   "devDependencies": {
     "ts-loader": "^9.4.2",

--- a/tests/functional/yarn.lock
+++ b/tests/functional/yarn.lock
@@ -286,6 +286,28 @@
     webpack-cli "^5.0.1"
     yargs "^17.7.1"
 
+"@heartexlabs/ls-test@git+ssh://git@github.com/heartexlabs/ls-frontend-test#c5b8083cbaf25d279e5d4da7c1a4a7f8ebf1eb7b":
+  version "1.0.8"
+  resolved "git+ssh://git@github.com/heartexlabs/ls-frontend-test#c5b8083cbaf25d279e5d4da7c1a4a7f8ebf1eb7b"
+  dependencies:
+    "@cypress/code-coverage" "^3.10.0"
+    "@cypress/webpack-preprocessor" "^5.17.0"
+    chai "^4.3.7"
+    cypress "^12.9.0"
+    cypress-image-snapshot "^4.0.1"
+    cypress-multi-reporters "^1.6.2"
+    cypress-parallel "^0.12.0"
+    cypress-plugin-snapshots "^1.4.4"
+    cypress-terminal-report "^5.1.1"
+    pixelmatch "^5.3.0"
+    pngjs "^7.0.0"
+    proper-lockfile "^4.1.2"
+    ts-loader "^9.4.2"
+    typescript "^4.9.5"
+    webpack "^5.77.0"
+    webpack-cli "^5.0.1"
+    yargs "^17.7.1"
+
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz#fd3db1d59ecf7cf121e80650bb86712f9b55eced"


### PR DESCRIPTION
The fix https://github.com/HumanSignal/label-studio-frontend/pull/1516 broke RichText functionality under the flag `fflag_feat_front_lsdv_4620_richtext_opimization_060423_short`.
This PR should fix it.

### PR fulfills these requirements
- [x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)

#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [x] Frontend

#### What libraries were added/updated?
N/A

#### Does this change affect performance?
Nope

#### Does this change affect security?
Nope

#### What alternative approaches were there?
N/A

#### What feature flags were used to cover this change?
`fflag_feat_front_lsdv_4620_richtext_opimization_060423_short`

### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [x] No
- [ ] Not sure (briefly explain the situation below)



### What level of testing was included in the change?
_(check all that apply)_
- [ ] e2e
- [ ] integration
- [ ] unit


### Which logical domain(s) does this change affect?
`RichText`