### PR TITLE
feat: OPTIC-3: Enable users to submit and pause their lead time by returning to the dm list 

### DIFF
--- a/src/components/BottomBar/Controls.js
+++ b/src/components/BottomBar/Controls.js
@@ -219,7 +219,6 @@ export const Controls = controlsInjector(observer(({ store, history, annotation 
         const title = submitDisabled
           ? 'Empty annotations denied in this project'
           : 'Save results: [ Ctrl+Enter ]';
-        // span is to display tooltip for disabled button
   
         buttons.push(
           <ButtonTooltip key="submit" title={title}>

--- a/src/components/BottomBar/Controls.js
+++ b/src/components/BottomBar/Controls.js
@@ -160,7 +160,6 @@ export const Controls = controlsInjector(observer(({ store, history, annotation 
                   >
                     <div>
                       <LsChevron />
-                      <Elem name="blind-width"></Elem>
                     </div>
                   </Dropdown.Trigger>
                 )}

--- a/src/components/BottomBar/Controls.js
+++ b/src/components/BottomBar/Controls.js
@@ -132,8 +132,6 @@ export const Controls = controlsInjector(observer(({ store, history, annotation 
     }
 
     const look = (disabled || submitDisabled) ? 'disabled' : 'primary';
-
-
     
     if (isFF(FF_PROD_E_111)) {
       const SubmitOption = ({ isUpdate, onClickMethod }) => {
@@ -160,42 +158,8 @@ export const Controls = controlsInjector(observer(({ store, history, annotation 
           </Button>
         );
       };
-      const createButton = (key, title, onClickMethod, isUpdate = false) => {
-        const isDisabled = disabled || submitDisabled;
-        const useExitOption = !isDisabled && isNotQuickView;
-
-        return (
-          <ButtonTooltip key={key} title={title}>
-            <Elem name="tooltip-wrapper">
-              <Button
-                aria-label="submit"
-                name="submit"
-                mod={{ has_icon: useExitOption, disabled: isDisabled }}
-                disabled={isDisabled}
-                look={look}
-                icon={useExitOption &&(
-                  <Dropdown.Trigger
-                    content={<SubmitOption onClickMethod={onClickMethod} isUpdate={isUpdate} />}
-                  >
-                    <div>
-                      <LsChevron />
-                    </div>
-                  </Dropdown.Trigger>
-                )}
-                onClick={async (event) => {
-                  if (event.target.classList.contains('lsf-dropdown__trigger')) return;
-                  await store.commentStore.commentFormSubmit();
-                  onClickMethod();
-                }}
-              >
-                {isUpdate ? 'Update' : 'Submit'}
-              </Button>
-            </Elem>
-          </ButtonTooltip>
-        );
-      };
       
-      const conditions = [
+      const submitConditions = [
         {
           check: (userGenerate) || (store.explore && !userGenerate && store.hasInterface('submit')),
           key: 'submit',
@@ -211,13 +175,43 @@ export const Controls = controlsInjector(observer(({ store, history, annotation 
         },
       ];
       
-      conditions.forEach((condition) => {
+      submitConditions.forEach((condition) => {
         if (condition.check) {
-          buttons.push(createButton(condition.key, condition.title, condition.method, condition.isUpdate));
+          const isDisabled = disabled || submitDisabled;
+          const useExitOption = !isDisabled && isNotQuickView;
+
+          buttons.push(
+            <ButtonTooltip key={condition.key} title={condition.title}>
+              <Elem name="tooltip-wrapper">
+                <Button
+                  aria-label="submit"
+                  name="submit"
+                  mod={{ has_icon: useExitOption, disabled: isDisabled }}
+                  disabled={isDisabled}
+                  look={look}
+                  icon={useExitOption &&(
+                    <Dropdown.Trigger
+                      content={<SubmitOption onClickMethod={condition.method} isUpdate={condition.isUpdate} />}
+                    >
+                      <div>
+                        <LsChevron />
+                      </div>
+                    </Dropdown.Trigger>
+                  )}
+                  onClick={async (event) => {
+                    if (event.target.classList.contains('lsf-dropdown__trigger')) return;
+                    await store.commentStore.commentFormSubmit();
+                    if (condition.key === 'submit') store.submitAnnotation();
+                    if (condition.key === 'update') store.updateAnnotation();
+                  }}
+                >
+                  {condition.isUpdate ? 'Update' : 'Submit'}
+                </Button>
+              </Elem>
+            </ButtonTooltip>,
+          );
         }
       });
-      
-
     } else {
       if ((userGenerate) || (store.explore && !userGenerate && store.hasInterface('submit'))) {
         const title = submitDisabled

--- a/src/components/BottomBar/Controls.js
+++ b/src/components/BottomBar/Controls.js
@@ -136,11 +136,25 @@ export const Controls = controlsInjector(observer(({ store, history, annotation 
 
     
     if (isFF(FF_PROD_E_111)) {
-      const SubmitOption = ({ isUpdate }) => {
+      const SubmitOption = ({ isUpdate, onClickMethod }) => {
         return (
           <Button
             name="list-button"
             look="secondary"
+            onClick={async (event) => {
+              event.preventDefault();
+              
+              if ('URLSearchParams' in window) {
+                const searchParams = new URLSearchParams(window.location.search);
+
+                searchParams.set('exitStream', 'true');
+                const newRelativePathQuery = window.location.pathname + '?' + searchParams.toString();
+
+                window.history.pushState(null, '', newRelativePathQuery);
+              }
+              await store.commentStore.commentFormSubmit();
+              onClickMethod();
+            }}
           >
             {`${isUpdate ? 'Update' : 'Submit'} and exit`}
           </Button>
@@ -157,7 +171,7 @@ export const Controls = controlsInjector(observer(({ store, history, annotation 
                 look={look}
                 icon={(
                   <Dropdown.Trigger
-                    content={<SubmitOption />}
+                    content={<SubmitOption onClickMethod={onClickMethod} isUpdate={isUpdate} />}
                   >
                     <div>
                       <LsChevron />

--- a/src/components/BottomBar/Controls.js
+++ b/src/components/BottomBar/Controls.js
@@ -133,18 +133,19 @@ export const Controls = controlsInjector(observer(({ store, history, annotation 
 
     const look = (disabled || submitDisabled) ? 'disabled' : 'primary';
 
-    const SubmitOption = ({ isUpdate }) => {
-      return (
-        <Button
-          name="list-button"
-          look="secondary"
-        >
-          {`${isUpdate ? 'Update' : 'Submit'} and exit`}
-        </Button>
-      );
-    };
+
     
     if (isFF(FF_PROD_E_111)) {
+      const SubmitOption = ({ isUpdate }) => {
+        return (
+          <Button
+            name="list-button"
+            look="secondary"
+          >
+            {`${isUpdate ? 'Update' : 'Submit'} and exit`}
+          </Button>
+        );
+      };
       const createButton = (key, title, onClickMethod, isUpdate = false) => {
         return (
           <ButtonTooltip key={key} title={title}>

--- a/src/components/BottomBar/Controls.js
+++ b/src/components/BottomBar/Controls.js
@@ -131,9 +131,9 @@ export const Controls = controlsInjector(observer(({ store, history, annotation 
       );
     }
 
-    
+    const look = (disabled || submitDisabled) ? 'disabled' : 'primary';
+
     if (isFF(FF_PROD_E_111)) {
-      const look = (disabled || submitDisabled) ? 'disabled' : 'primary';
       const isDisabled = disabled || submitDisabled;
       const useExitOption = !isDisabled && isNotQuickView;
 
@@ -216,7 +216,7 @@ export const Controls = controlsInjector(observer(({ store, history, annotation 
               }}
               icon={useExitOption &&(
                 <Dropdown.Trigger
-                  content={<SubmitOption onClickMethod={store.updateAnnotation} isUpdate={false} />}
+                  content={<SubmitOption onClickMethod={store.updateAnnotation} isUpdate={isUpdate} />}
                 >
                   <div>
                     <LsChevron />

--- a/src/components/BottomBar/Controls.js
+++ b/src/components/BottomBar/Controls.js
@@ -161,16 +161,19 @@ export const Controls = controlsInjector(observer(({ store, history, annotation 
         );
       };
       const createButton = (key, title, onClickMethod, isUpdate = false) => {
+        const isDisabled = disabled || submitDisabled;
+        const useExitOption = !isDisabled && isNotQuickView;
+
         return (
           <ButtonTooltip key={key} title={title}>
             <Elem name="tooltip-wrapper">
               <Button
                 aria-label="submit"
                 name="submit"
-                mod={{ has_icon: !isNotQuickView }}
-                disabled={disabled || submitDisabled}
+                mod={{ has_icon: useExitOption, disabled: isDisabled }}
+                disabled={isDisabled}
                 look={look}
-                icon={isNotQuickView &&(
+                icon={useExitOption &&(
                   <Dropdown.Trigger
                     content={<SubmitOption onClickMethod={onClickMethod} isUpdate={isUpdate} />}
                   >

--- a/src/components/BottomBar/Controls.js
+++ b/src/components/BottomBar/Controls.js
@@ -131,9 +131,13 @@ export const Controls = controlsInjector(observer(({ store, history, annotation 
       );
     }
 
-    const look = (disabled || submitDisabled) ? 'disabled' : 'primary';
     
     if (isFF(FF_PROD_E_111)) {
+      const look = (disabled || submitDisabled) ? 'disabled' : 'primary';
+      const isDisabled = disabled || submitDisabled;
+      const useExitOption = !isDisabled && isNotQuickView;
+
+
       const SubmitOption = ({ isUpdate, onClickMethod }) => {
         return (
           <Button
@@ -158,60 +162,75 @@ export const Controls = controlsInjector(observer(({ store, history, annotation 
           </Button>
         );
       };
-      
-      const submitConditions = [
-        {
-          check: (userGenerate) || (store.explore && !userGenerate && store.hasInterface('submit')),
-          key: 'submit',
-          title: submitDisabled ? 'Empty annotations denied in this project' : 'Save results: [ Ctrl+Enter ]',
-          method: store.submitAnnotation,
-        },
-        {
-          check: (userGenerate && sentUserGenerate) || (!userGenerate && store.hasInterface('update')),
-          key: 'update',
-          title: 'Update this task: [ Alt+Enter ]',
-          method: store.updateAnnotation,
-          isUpdate: sentUserGenerate || versions.result,
-        },
-      ];
-      
-      submitConditions.forEach((condition) => {
-        if (condition.check) {
-          const isDisabled = disabled || submitDisabled;
-          const useExitOption = !isDisabled && isNotQuickView;
 
-          buttons.push(
-            <ButtonTooltip key={condition.key} title={condition.title}>
-              <Elem name="tooltip-wrapper">
-                <Button
-                  aria-label="submit"
-                  name="submit"
-                  mod={{ has_icon: useExitOption, disabled: isDisabled }}
-                  disabled={isDisabled}
-                  look={look}
-                  icon={useExitOption &&(
-                    <Dropdown.Trigger
-                      content={<SubmitOption onClickMethod={condition.method} isUpdate={condition.isUpdate} />}
-                    >
-                      <div>
-                        <LsChevron />
-                      </div>
-                    </Dropdown.Trigger>
-                  )}
-                  onClick={async (event) => {
-                    if (event.target.classList.contains('lsf-dropdown__trigger')) return;
-                    await store.commentStore.commentFormSubmit();
-                    if (condition.key === 'submit') store.submitAnnotation();
-                    if (condition.key === 'update') store.updateAnnotation();
-                  }}
+      if ((userGenerate) || (store.explore && !userGenerate && store.hasInterface('submit'))) {
+        const title = submitDisabled
+          ? 'Empty annotations denied in this project'
+          : 'Save results: [ Ctrl+Enter ]';
+
+        buttons.push(
+          <ButtonTooltip key="submit" title={title}>
+            <Elem name="tooltip-wrapper">
+              <Button
+                aria-label="submit"
+                name="submit"
+                disabled={isDisabled}
+                look={look}
+                mod={{ has_icon: useExitOption, disabled: isDisabled }}
+                onClick={async (event) => {
+                  if (event.target.classList.contains('lsf-dropdown__trigger')) return;  
+                  await store.commentStore.commentFormSubmit();
+                  store.submitAnnotation();
+                }}
+                icon={useExitOption &&(
+                  <Dropdown.Trigger
+                    content={<SubmitOption onClickMethod={store.submitAnnotation} isUpdate={false} />}
+                  >
+                    <div>
+                      <LsChevron />
+                    </div>
+                  </Dropdown.Trigger>
+                )}
+              >
+              Submit
+              </Button>
+            </Elem>
+          </ButtonTooltip>,
+        );
+      }
+
+      if ((userGenerate && sentUserGenerate) || (!userGenerate && store.hasInterface('update'))) {
+        const isUpdate = sentUserGenerate || versions.result;
+        const button = (
+          <ButtonTooltip key="update" title="Update this task: [ Alt+Enter ]">
+            <Button
+              aria-label="submit"
+              name="submit"
+              disabled={disabled || submitDisabled}
+              look={look}
+              mod={{ has_icon: useExitOption, disabled: isDisabled }}
+              onClick={async (event) => {
+                if (event.target.classList.contains('lsf-dropdown__trigger')) return;
+                await store.commentStore.commentFormSubmit();
+                store.updateAnnotation();
+              }}
+              icon={useExitOption &&(
+                <Dropdown.Trigger
+                  content={<SubmitOption onClickMethod={store.updateAnnotation} isUpdate={false} />}
                 >
-                  {condition.isUpdate ? 'Update' : 'Submit'}
-                </Button>
-              </Elem>
-            </ButtonTooltip>,
-          );
-        }
-      });
+                  <div>
+                    <LsChevron />
+                  </div>
+                </Dropdown.Trigger>
+              )}
+            >
+              {isUpdate ? 'Update' : 'Submit'}
+            </Button>
+          </ButtonTooltip>
+        );
+
+        buttons.push(button);
+      }  
     } else {
       if ((userGenerate) || (store.explore && !userGenerate && store.hasInterface('submit'))) {
         const title = submitDisabled

--- a/src/components/BottomBar/Controls.js
+++ b/src/components/BottomBar/Controls.js
@@ -33,7 +33,7 @@ const controlsInjector = inject(({ store }) => {
 
 export const Controls = controlsInjector(observer(({ store, history, annotation }) => {
   const isReview = store.hasInterface('review');
-  
+  const isNotQuickView = store.hasInterface('topbar:prevnext');
   const historySelected = isDefined(store.annotationStore.selectedHistory);
   const { userGenerate, sentUserGenerate, versions, results, editable: annotationEditable } = annotation;
   const buttons = [];
@@ -167,9 +167,10 @@ export const Controls = controlsInjector(observer(({ store, history, annotation 
               <Button
                 aria-label="submit"
                 name="submit"
+                mod={{ has_icon: !isNotQuickView }}
                 disabled={disabled || submitDisabled}
                 look={look}
-                icon={(
+                icon={isNotQuickView &&(
                   <Dropdown.Trigger
                     content={<SubmitOption onClickMethod={onClickMethod} isUpdate={isUpdate} />}
                   >

--- a/src/components/BottomBar/Controls.styl
+++ b/src/components/BottomBar/Controls.styl
@@ -27,7 +27,7 @@
       height 40px
       justify-content space-between
       align-items center
-      color var(--primary-palette-light-theme-on-primary, #FFF)
+      color #FFF
       text-align center
       font-size 16px
       font-style normal
@@ -48,7 +48,7 @@
         justify-content center
         align-items center
         align-self stretch
-        border-left 1px solid var(--primary-palette-light-theme-on-primary-opacity-on-primary-opacity-16, rgba(255, 255, 255, 0.16))
+        border-left 1px solid rgba(255, 255, 255, 0.16)
 
         svg 
           pointer-events none
@@ -92,7 +92,7 @@
   position absolute
   right -32px
   bottom 36px
-  background var(--neutral-palette-light-theme-surface-surface, #FAFAFA)
+  background #FAFAFA
   box-shadow: 0px 1px 3px 1px rgba(38, 38, 38, 0.15), 0px 1px 2px 0px rgba(38, 38, 38, 0.30);
   font-size 16px
   font-style normal

--- a/src/components/BottomBar/Controls.styl
+++ b/src/components/BottomBar/Controls.styl
@@ -54,15 +54,6 @@
           pointer-events none
           transform: rotate(180deg) translateY(-4px) scale(1.1)
 
-      &__blind-width
-        position absolute
-        right 0
-        background orange
-        top 0
-        width 160px
-        pointer-events none
-
-
     &__skipped-info
       display flex
       // background-color rgba(221, 0, 0, 0.18)

--- a/src/components/BottomBar/Controls.styl
+++ b/src/components/BottomBar/Controls.styl
@@ -25,7 +25,7 @@
       display flex
       width 160px
       height 40px
-      justify-content space-between
+      justify-content center
       align-items center
       color #FFF
       text-align center
@@ -37,6 +37,9 @@
       flex-direction row-reverse
       padding 0
 
+      &__has_icon
+        justify-content space-between
+
       span  
         width 100%
 
@@ -44,15 +47,21 @@
         display flex
         max-width 40px 
         height 100%
-        padding 8px
         justify-content center
         align-items center
         align-self stretch
         border-left 1px solid rgba(255, 255, 255, 0.16)
 
+        div
+          width 100%
+          height 100%
+          display flex
+          align-items center
+          justify-content center
+
         svg 
           pointer-events none
-          transform: rotate(180deg) translateY(-4px) scale(1.1)
+          transform: rotate(180deg) scale(1.1)
 
     &__skipped-info
       display flex

--- a/src/components/BottomBar/Controls.styl
+++ b/src/components/BottomBar/Controls.styl
@@ -37,6 +37,10 @@
       flex-direction row-reverse
       padding 0
 
+      &_disabled 
+        color: rgba(255,255,255,0.8);
+        background-color: #bbb;
+
       &__has_icon
         justify-content space-between
 
@@ -99,8 +103,8 @@
 .list-button
   width 169px
   position absolute
-  right -32px
-  bottom 36px
+  right -40px
+  bottom 40px
   background #FAFAFA
   box-shadow: 0px 1px 3px 1px rgba(38, 38, 38, 0.15), 0px 1px 2px 0px rgba(38, 38, 38, 0.30);
   font-size 16px

--- a/src/components/BottomBar/Controls.styl
+++ b/src/components/BottomBar/Controls.styl
@@ -18,6 +18,51 @@
       &_look_danger
         border-color #e1e0e2
 
+    .submit
+      border-radius 4px
+      background #09F
+      box-shadow 0px 4px 4px 0px rgba(0, 0, 0, 0.25)
+      display flex
+      width 160px
+      height 40px
+      justify-content space-between
+      align-items center
+      color var(--primary-palette-light-theme-on-primary, #FFF)
+      text-align center
+      font-size 16px
+      font-style normal
+      font-weight 500
+      line-height 24px
+      letter-spacing 0.15px
+      flex-direction row-reverse
+      padding 0
+
+      span  
+        width 100%
+
+      &__icon
+        display flex
+        max-width 40px 
+        height 100%
+        padding 8px
+        justify-content center
+        align-items center
+        align-self stretch
+        border-left 1px solid var(--primary-palette-light-theme-on-primary-opacity-on-primary-opacity-16, rgba(255, 255, 255, 0.16))
+
+        svg 
+          pointer-events none
+          transform: rotate(180deg) translateY(-4px) scale(1.1)
+
+      &__blind-width
+        position absolute
+        right 0
+        background orange
+        top 0
+        width 160px
+        pointer-events none
+
+
     &__skipped-info
       display flex
       // background-color rgba(221, 0, 0, 0.18)
@@ -50,3 +95,31 @@
       display flex
       flex-direction row
       justify-content end
+
+.list-button
+  width 169px
+  position absolute
+  right -32px
+  bottom 36px
+  background var(--neutral-palette-light-theme-surface-surface, #FAFAFA)
+  box-shadow: 0px 1px 3px 1px rgba(38, 38, 38, 0.15), 0px 1px 2px 0px rgba(38, 38, 38, 0.30);
+  font-size 16px
+  font-style normal
+  font-weight 400
+  line-height 24px
+  letter-spacing 0.5px
+
+  &:hover:before 
+    content ''
+    z-index auto
+    background #00f
+    width calc(100% - 16px)
+    height calc(100% - 16px)
+    position absolute
+    left 0
+    top 0
+    margin 8px
+    border-radius 4px
+    opacity 0.08
+    background rgb(9 109 217)
+    pointer-events none

--- a/src/utils/feature-flags.ts
+++ b/src/utils/feature-flags.ts
@@ -16,9 +16,6 @@ export const FF_DEV_1284 = 'fflag_fix_front_dev_1284_auto_detect_undo_281022_sho
 // Fix crosshair working with zoom & rotation
 export const FF_DEV_1285 = 'ff_front_dev_1285_crosshair_wrong_zoom_140122_short';
 
-// Add visibleWhen="choice-unselected" option
-export const FF_DEV_1372 = 'ff_front_dev_1372_visible_when_choice_unselected_11022022_short';
-
 export const FF_DEV_1442 = 'ff_front_dev_1442_unselect_shape_on_click_outside_080622_short';
 
 // Keep enabled state of video region on area transformations

--- a/src/utils/feature-flags.ts
+++ b/src/utils/feature-flags.ts
@@ -313,7 +313,6 @@ export const FF_TAXONOMY_LABELING = 'fflag_feat_front_lsdv_5452_taxonomy_labelin
 
 /**
  * Annotator workflow control for lead time calculation
- * @link https://app.launchdarkly.com/default/production/features/fflag_feat_front_lsdv_5452_taxonomy_labeling_110823_short
  */
 export const FF_PROD_E_111 = 'fflag_feat_front_prod_e_111_annotator_workflow_control_short';
 

--- a/src/utils/feature-flags.ts
+++ b/src/utils/feature-flags.ts
@@ -16,6 +16,9 @@ export const FF_DEV_1284 = 'fflag_fix_front_dev_1284_auto_detect_undo_281022_sho
 // Fix crosshair working with zoom & rotation
 export const FF_DEV_1285 = 'ff_front_dev_1285_crosshair_wrong_zoom_140122_short';
 
+// Add visibleWhen="choice-unselected" option
+export const FF_DEV_1372 = 'ff_front_dev_1372_visible_when_choice_unselected_11022022_short';
+
 export const FF_DEV_1442 = 'ff_front_dev_1442_unselect_shape_on_click_outside_080622_short';
 
 // Keep enabled state of video region on area transformations
@@ -310,6 +313,13 @@ export const FF_TAXONOMY_ASYNC = 'fflag_feat_front_lsdv_5451_async_taxonomy_1108
  * @link https://app.launchdarkly.com/default/production/features/fflag_feat_front_lsdv_5452_taxonomy_labeling_110823_short
  */
 export const FF_TAXONOMY_LABELING = 'fflag_feat_front_lsdv_5452_taxonomy_labeling_110823_short';
+
+/**
+ * Annotator workflow control for lead time calculation
+ * @link https://app.launchdarkly.com/default/production/features/fflag_feat_front_lsdv_5452_taxonomy_labeling_110823_short
+ */
+export const FF_PROD_E_111 = 'fflag_feat_front_prod_e_111_annotator_workflow_control_short';
+
 
 Object.assign(window, {
   APP_SETTINGS: {


### PR DESCRIPTION
### PR fulfills these requirements
- [X] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [X] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [X] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [X] Frontend



### Describe the reason for change
An option submit/update and exit the stream to stop lead time from running on


#### What does this fix?
feature


#### What is the new behavior?
you are able to submit and not load another task and instead return to the datamanager list

#### What is the current behavior?
if you want to take a break you would have to close the window

#### What libraries were added/updated?
N/A


#### Does this change affect performance?
no


#### Does this change affect security?
no


#### What alternative approaches were there?
There are likely numerous methods for passing information to the LSF SDK. However, since we were already utilizing query parameters in the 'submit' function, it made sense to continue using this approach for passing a temporary flag to the SDK. This method is convenient because it avoids interfering with the existing chain of functions that have been scaffolded between the two stores.


#### What feature flags were used to cover this change?
fflag_feat_front_prod_e_111_annotator_workflow_control_short


### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [X] No
- [ ] Not sure (briefly explain the situation below)



### What level of testing was included in the change?
_(check all that apply)_
- [ ] e2e
- [ ] integration
- [ ] unit



### Which logical domain(s) does this change affect?
_(for bug fixes/features, be as precise as possible. ex. Authentication, Annotation History, Review Stream etc.)_

