### PR TITLE
fix: LSDV-5487: Keep the labeling interface settings after change page

### DIFF
--- a/src/stores/SettingsStore.js
+++ b/src/stores/SettingsStore.js
@@ -62,6 +62,8 @@ const SettingsModel = types
     enableSmoothing: types.optional(types.boolean, true),
 
     videoHopSize: types.optional(types.number, 10),
+
+    isDestroying: types.optional(types.boolean, false),
   })
   .views(self => ({
     get annotation() {
@@ -72,6 +74,9 @@ const SettingsModel = types
     },
   }))
   .actions(self => ({
+    beforeDestroy() {
+      self.isDestroying = true;
+    },
     afterCreate() {
       // sandboxed environment may break even on check of this property
       try {
@@ -109,7 +114,11 @@ const SettingsModel = types
 
       // capture changes and save it
       onSnapshot(self, ss => {
-        localStorage.setItem(lsKey, JSON.stringify(ss));
+        // it's necessary to wait 1 tick before check if self.isDestroying is true
+        setTimeout(() => {
+          if (!self.isDestroying)
+            localStorage.setItem(lsKey, JSON.stringify(ss));
+        });
       });
     },
 


### PR DESCRIPTION
### PR fulfills these requirements
- [x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [x] Frontend



### Describe the reason for change
The labeling interface settings wasn't keeping after user changes page, all storages are being destroyed on AppStore when user leaves the Annotation Engine and when SettingsStore is destroyed, it's triggering onSnapshot method, and changing the saved config on the localStorage with the default variables on the store.


#### What does this fix?
The fix is validating if store is being destroyed and if it's being destroyed it's avoid that localStorage is set with the default values from the store



#### What is the new behavior?
_(if this is a breaking or feature change)_



#### What is the current behavior?
_(if this is a breaking or feature change)_



#### What libraries were added/updated?
_(list all with version changes)_



#### Does this change affect performance?
_(if so describe the impacts positive or negative)_



#### Does this change affect security?
_(if so describe the impacts positive or negative)_



#### What alternative approaches were there?
_(briefly list any if applicable)_



#### What feature flags were used to cover this change?
_(briefly list any if applicable)_



### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [ ] No
- [ ] Not sure (briefly explain the situation below)



### What level of testing was included in the change?
_(check all that apply)_
- [ ] e2e
- [ ] integration
- [ ] unit



### Which logical domain(s) does this change affect?
_(for bug fixes/features, be as precise as possible. ex. Authentication, Annotation History, Review Stream etc.)_
