### PR TITLE
fix: LSDV-5547: Support HTML in Instructions modal

### DIFF
--- a/src/components/InstructionsModal/InstructionsModal.tsx
+++ b/src/components/InstructionsModal/InstructionsModal.tsx
@@ -8,15 +8,17 @@ export const InstructionsModal = ({
   onCancel,
 }: {
   title: string,
-  children: string,
+  children: React.ReactNode,
   visible: boolean,
   onCancel: () => void,
 }) => {
+  const contentStyle: Record<string, string> = { padding: '0 24px 24px', whiteSpace: 'pre-wrap' };
+
   return (
     <>
       <Modal
         title=""
-        visible={visible}
+        open={visible}
         maskClosable
         footer={null}
         closable={true}
@@ -45,10 +47,14 @@ export const InstructionsModal = ({
         >
           {title}
         </h2>
-        <p
-          style={{ padding: '0 24px 24px', whiteSpace: 'pre-wrap' }}
-          dangerouslySetInnerHTML={{ __html: children }}
-        />
+        {typeof children === 'string' ? (
+          <p
+            style={contentStyle}
+            dangerouslySetInnerHTML={{ __html: children }}
+          />
+        ) : (
+          <p style={contentStyle}>{children}</p>
+        )}
       </Modal>
     </>
   );

--- a/src/components/InstructionsModal/InstructionsModal.tsx
+++ b/src/components/InstructionsModal/InstructionsModal.tsx
@@ -8,7 +8,7 @@ export const InstructionsModal = ({
   onCancel,
 }: {
   title: string,
-  children: React.ReactNode,
+  children: string,
   visible: boolean,
   onCancel: () => void,
 }) => {
@@ -45,7 +45,10 @@ export const InstructionsModal = ({
         >
           {title}
         </h2>
-        <p style={{ padding: '0 24px 24px', whiteSpace: 'pre-wrap' }}>{children}</p>
+        <p
+          style={{ padding: '0 24px 24px', whiteSpace: 'pre-wrap' }}
+          dangerouslySetInnerHTML={{ __html: children }}
+        />
       </Modal>
     </>
   );

--- a/src/components/InstructionsModal/InstructionsModal.tsx
+++ b/src/components/InstructionsModal/InstructionsModal.tsx
@@ -18,7 +18,7 @@ export const InstructionsModal = ({
     <>
       <Modal
         title=""
-        open={visible}
+        visible={visible}
         maskClosable
         footer={null}
         closable={true}

--- a/src/components/InstructionsModal/__tests__/InstructionsModal.test.tsx
+++ b/src/components/InstructionsModal/__tests__/InstructionsModal.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { InstructionsModal } from '../InstructionsModal';
 
 describe('InstructionsModal Component', () => {
@@ -14,6 +14,20 @@ describe('InstructionsModal Component', () => {
 
     expect(document.body.contains(getByText(title))).toBe(true);
     expect(document.body.contains(getByText('Test Children'))).toBe(true);
+  });
+
+  it('should render html', () => {
+    const title = 'Test Title';
+    const children = '<h1 style="color: red;">Test Children</h1>';
+
+    render(
+      <InstructionsModal title={title} visible={true} onCancel={() => {}}>
+        {children}
+      </InstructionsModal>,
+    );
+
+    expect(screen.queryByText('Test Children')).toBeTruthy();
+    expect(screen.queryByText('color: red')).toBeNull();
   });
 
   it('should call onCancel when the modal is cancelled', () => {


### PR DESCRIPTION
Format instructions as HTML the same way we do it in LS/LSE

### PR fulfills these requirements
- [x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
- [ ] Product design
- [x] Frontend



### Describe the reason for change
Discrepancy between Label Stream behavior, where instructions displayed in intro modal, formatted as HTML, and instructions modal opened by (i) button, where all HTML displayed as plain text.



#### What does this fix?
Formats instruction as HTML




#### Does this change affect security?
It dangerously displays instructions as HTML, this can use any scripts etc. But the same is used already in LS/LSE. And this instruction can be set only by managers.



#### What alternative approaches were there?
This exact task made as it should be. But we can add some layer of security, sandboxing the modal.



### Does this PR introduce a breaking change?

- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [x] No
- [ ] Not sure (briefly explain the situation below)



### What level of testing was included in the change?

- [ ] e2e
- [ ] integration
- [ ] unit



### Which logical domain(s) does this change affect?
Instructions, Label Stream
