### PR TITLE
fix: LEAP-235: Fix the property showFullPath to work as it was working in the old taxonomy

### DIFF
--- a/src/components/NewTaxonomy/NewTaxonomy.tsx
+++ b/src/components/NewTaxonomy/NewTaxonomy.tsx
@@ -94,6 +94,21 @@ const NewTaxonomy = ({
     return flatten;
   }, [items]);
 
+  const formatOutputValue = useMemo(() => {
+    return selected.map(path => {
+      const selectedItem = path.map(value => {
+        const label = flatten.find(taxonomyItem => taxonomyItem.path.at(-1) === value)?.label;
+
+        return label ?? value;
+      });
+
+      return {
+        label: options.showFullPath ? selectedItem.join(separator) : selectedItem[path.length - 1],
+        value: path.join(separator),
+      };
+    });
+  }, [selected]);
+
   const loadData = useCallback(async (node: any) => {
     return onLoadData?.(node.value.split(separator));
   }, []);
@@ -102,18 +117,7 @@ const NewTaxonomy = ({
     <TreeSelect
       treeData={treeData}
       labelInValue={true}
-      value={selected.map(path => {
-        const selectedItem = path.map(value => {
-          const label = flatten.find(taxonomyItem => taxonomyItem.path[taxonomyItem.path.length - 1] === value)?.label;
-
-          return label ?? value;
-        });
-
-        return {
-          label: options.showFullPath ? selectedItem.join(separator) : selectedItem[path.length - 1],
-          value: path.join(separator),
-        };
-      })}
+      value={formatOutputValue}
       onChange={items => onChange(null, items.map(item => item.value.split(separator)))}
       loadData={loadData}
       treeCheckable

--- a/src/components/NewTaxonomy/NewTaxonomy.tsx
+++ b/src/components/NewTaxonomy/NewTaxonomy.tsx
@@ -48,19 +48,18 @@ type TaxonomyProps = {
 };
 
 const convert = (items: TaxonomyItem[], options: TaxonomyOptions): AntTaxonomyItem[] => {
-  return items.map(item => {
-    return {
-      title: item.hint ? (
-        <Tooltip title={item.hint} mouseEnterDelay={500}>
-          <span>{item.label}</span>
-        </Tooltip>
-      ) : item.label,
-      value: item.path.join(options.pathSeparator),
-      key: item.path.join(options.pathSeparator),
-      isLeaf: item.isLeaf !== false && !item.children,
-      disableCheckbox: options.leafsOnly && (item.isLeaf === false || !!item.children),
-      children: item.children ? convert(item.children, options) : undefined,
-    };});
+  return items.map(item => ({
+    title: item.hint ? (
+      <Tooltip title={item.hint} mouseEnterDelay={500}>
+        <span>{item.label}</span>
+      </Tooltip>
+    ) : item.label,
+    value: item.path.join(options.pathSeparator),
+    key: item.path.join(options.pathSeparator),
+    isLeaf: item.isLeaf !== false && !item.children,
+    disableCheckbox: options.leafsOnly && (item.isLeaf === false || !!item.children),
+    children: item.children ? convert(item.children, options) : undefined,
+  }));
 };
 
 const NewTaxonomy = ({
@@ -115,9 +114,7 @@ const NewTaxonomy = ({
           value: path.join(separator),
         };
       })}
-      onChange={items => {
-        onChange(null, items.map(item => item.value.split(separator)));
-      }}
+      onChange={items => onChange(null, items.map(item => item.value.split(separator)))}
       loadData={loadData}
       treeCheckable
       treeCheckStrictly

--- a/src/components/NewTaxonomy/NewTaxonomy.tsx
+++ b/src/components/NewTaxonomy/NewTaxonomy.tsx
@@ -90,7 +90,11 @@ const NewTaxonomy = ({
   return (
     <TreeSelect
       treeData={treeData}
-      value={selected.map(path => path.join(separator))}
+      labelInValue={true}
+      value={selected.map(path => ({
+        label: options.showFullPath ? path.join(separator) : path[path.length - 1],
+        value: path.join(separator),
+      }))}
       onChange={items => onChange(null, items.map(item => item.value.split(separator)))}
       loadData={loadData}
       treeCheckable

--- a/src/components/NewTaxonomy/NewTaxonomy.tsx
+++ b/src/components/NewTaxonomy/NewTaxonomy.tsx
@@ -116,7 +116,6 @@ const NewTaxonomy = ({
         };
       })}
       onChange={items => {
-        console.log('heartex', items);
         onChange(null, items.map(item => item.value.split(separator)));
       }}
       loadData={loadData}

--- a/src/tags/control/Taxonomy/Taxonomy.js
+++ b/src/tags/control/Taxonomy/Taxonomy.js
@@ -33,6 +33,8 @@ import ControlBase from '../Base';
 import ClassificationBase from '../ClassificationBase';
 
 import styles from './Taxonomy.styl';
+import { errorBuilder } from '../../../core/DataValidator/ConfigValidator';
+import messages from '../../../utils/messages';
 
 /**
  * The `Taxonomy` tag is used to create one or more hierarchical classifications, storing both choice selections and their ancestors in the results. Use for nested classification tasks with the `Choice` tag.
@@ -360,8 +362,10 @@ const Model = types
           self._items = items;
         }
       } catch (err) {
+        const message = messages.ERR_LOADING_HTTP({ attr: 'apiUrl', error: err, url:self.apiurl });
+
         console.error(err);
-        Infomodal.error(`Failed to load taxonomy "${self.name}" from "${self.apiurl}" by path "${path}".`);
+        self.annotationStore.addErrors([errorBuilder.generalError(message)]);
       }
 
       self.loading = false;

--- a/src/tags/control/Taxonomy/Taxonomy.js
+++ b/src/tags/control/Taxonomy/Taxonomy.js
@@ -33,8 +33,6 @@ import ControlBase from '../Base';
 import ClassificationBase from '../ClassificationBase';
 
 import styles from './Taxonomy.styl';
-import { errorBuilder } from '../../../core/DataValidator/ConfigValidator';
-import messages from '../../../utils/messages';
 
 /**
  * The `Taxonomy` tag is used to create one or more hierarchical classifications, storing both choice selections and their ancestors in the results. Use for nested classification tasks with the `Choice` tag.
@@ -362,10 +360,8 @@ const Model = types
           self._items = items;
         }
       } catch (err) {
-        const message = messages.ERR_LOADING_HTTP({ attr: 'apiUrl', error: err, url:self.apiurl });
-
         console.error(err);
-        self.annotationStore.addErrors([errorBuilder.generalError(message)]);
+        Infomodal.error(`Failed to load taxonomy "${self.name}" from "${self.apiurl}" by path "${path}".`);
       }
 
       self.loading = false;


### PR DESCRIPTION
### PR fulfills these requirements
- [ x Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [x] Frontend



### Describe the reason for change
The property showFullPath is not working on the new taxonomy and it should be working as it was working in the old Taxonomy



#### What does this fix?
It is fixing the property showFullPath in the new Taxonomy, with this fix if user set the property showFullPath in the Taxonomy tag, when user selects a item, it will start showing all the path using ' / ' to separate each tag.


#### What libraries were added/updated?
No



#### Does this change affect performance?
No



#### Does this change affect security?
No


#### What alternative approaches were there?
As it is a specific fix, I don't think that it would be possible to use an alternative approache



#### What feature flags were used to cover this change?
fflag_feat_front_lsdv_5451_async_taxonomy_110823_short



### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [x] No
- [ ] Not sure (briefly explain the situation below)



### What level of testing was included in the change?
_(check all that apply)_
- [ ] e2e
- [ ] integration
- [ ] unit
