### PR TITLE
fix: LEAP-256: Include the 'legacy' property in the 'Taxonomy' tag

### DIFF
--- a/src/tags/control/Taxonomy/Taxonomy.js
+++ b/src/tags/control/Taxonomy/Taxonomy.js
@@ -75,7 +75,6 @@ import styles from './Taxonomy.styl';
  * @param {string} [placeholder=]         - What to display as prompt on the input
  * @param {boolean} [perRegion]           - Use this tag to classify specific regions instead of the whole object
  * @param {boolean} [perItem]             - Use this tag to classify specific items inside the object instead of the whole object[^FF_LSDV_4583]
- * @param {boolean} [legacy]              - Use this tag to display the legacy version of the Taxonomy[^FF_TAXONOMY_ASYNC]
  */
 const TagAttrs = types.model({
   toname: types.maybeNull(types.string),

--- a/src/tags/control/Taxonomy/Taxonomy.js
+++ b/src/tags/control/Taxonomy/Taxonomy.js
@@ -75,12 +75,14 @@ import styles from './Taxonomy.styl';
  * @param {string} [placeholder=]         - What to display as prompt on the input
  * @param {boolean} [perRegion]           - Use this tag to classify specific regions instead of the whole object
  * @param {boolean} [perItem]             - Use this tag to classify specific items inside the object instead of the whole object[^FF_LSDV_4583]
+ * @param {boolean} [legacy]              - Use this tag to display the legacy version of the Taxonomy[^FF_TAXONOMY_ASYNC]
  */
 const TagAttrs = types.model({
   toname: types.maybeNull(types.string),
   labeling: types.optional(types.boolean, false),
   leafsonly: types.optional(types.boolean, false),
   showfullpath: types.optional(types.boolean, false),
+  legacy: types.optional(types.boolean, false),
   pathseparator: types.optional(types.string, ' / '),
   apiurl: types.maybeNull(types.string),
   placeholder: '',
@@ -512,7 +514,7 @@ const HtxTaxonomy = observer(({ item }) => {
   return (
     // @todo use BEM class names + literal "taxonomy" for external styling
     <div className={[styles.taxonomy, 'taxonomy'].join(' ')} style={{ ...visibleStyle }}>
-      {isFF(FF_TAXONOMY_ASYNC) ? (
+      {(isFF(FF_TAXONOMY_ASYNC) && !item.legacy) ? (
         <NewTaxonomy
           items={item.items}
           selected={item.selected}


### PR DESCRIPTION
### PR fulfills these requirements
- [x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [x] Frontend



### Describe the reason for change
A lot of things was changed in New Taxonomy, so some slight regression is possible in some cases, so some clients may want to use the old one.


#### What does this fix?
Include the 'legacy' property in the 'Taxonomy' tag, allowing users to access the legacy version, even when the feature flag is enabled.



#### What libraries were added/updated?
no


#### Does this change affect performance?
no



#### Does this change affect security?
no


#### What alternative approaches were there?
no



#### What feature flags were used to cover this change?
fflag_feat_front_lsdv_5451_async_taxonomy_110823_short


### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [x] No
- [ ] Not sure (briefly explain the situation below)



### What level of testing was included in the change?
_(check all that apply)_
- [ ] e2e
- [ ] integration
- [ ] unit
