### PR TITLE
fix: LEAP-252: Use standard error message for Async Taxonomy errors

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -94,7 +94,7 @@ jobs:
         run: |
           set -euo pipefail
           cd e2e
-          yarn run test:ci ${{ steps.cpu-info.outputs.cores-count }}
+          yarn run test:ci ${{ steps.cpu-info.outputs.cores-count }} --debug --verbose
 
       - name: "Upload e2e output" 
         uses: ./.github/actions/upload-artifact

--- a/src/tags/control/Taxonomy/Taxonomy.js
+++ b/src/tags/control/Taxonomy/Taxonomy.js
@@ -33,6 +33,8 @@ import ControlBase from '../Base';
 import ClassificationBase from '../ClassificationBase';
 
 import styles from './Taxonomy.styl';
+import messages from '../../../utils/messages';
+import { errorBuilder } from '../../../core/DataValidator/ConfigValidator';
 
 /**
  * The `Taxonomy` tag is used to create one or more hierarchical classifications, storing both choice selections and their ancestors in the results. Use for nested classification tasks with the `Choice` tag.
@@ -360,8 +362,10 @@ const Model = types
           self._items = items;
         }
       } catch (err) {
+        const message = messages.ERR_LOADING_HTTP({ attr: 'apiUrl', error: err, url:self.apiurl });
+
         console.error(err);
-        Infomodal.error(`Failed to load taxonomy "${self.name}" from "${self.apiurl}" by path "${path}".`);
+        self.annotationStore.addErrors([errorBuilder.generalError(message)]);
       }
 
       self.loading = false;

--- a/src/tags/control/Taxonomy/Taxonomy.js
+++ b/src/tags/control/Taxonomy/Taxonomy.js
@@ -404,6 +404,7 @@ const Model = types
 
       self.loading = false;
     },
+
     requiredModal() {
       Infomodal.warning(self.requiredmessage || `Taxonomy "${self.name}" is required.`);
     },

--- a/src/tags/control/Taxonomy/Taxonomy.js
+++ b/src/tags/control/Taxonomy/Taxonomy.js
@@ -341,7 +341,15 @@ const Model = types
 
 
       try {
-        const res = yield fetch(url);
+        const res = yield fetch(url)
+          .then(res => {
+            if (!res.ok) {
+              self.setError(res.status);
+            }
+          }).catch(err => {
+            self.setError(err);
+          });
+        
         const dataRaw = yield res.json();
         // @todo temporary to support deprecated API response format (just array, no items)
         const data = dataRaw.items ?? dataRaw;
@@ -356,10 +364,6 @@ const Model = types
         });
         const items = convert(data, prefix);
 
-        res.catch(err => {
-          self.setError(err);
-        });
-
         if (path) {
           item.children = items;
           self._items = [...self._items];
@@ -367,7 +371,7 @@ const Model = types
           self._items = items;
         }
       } catch (err) {
-        self.setError(err);
+        console.error(err);
       }
 
       self.loading = false;

--- a/src/tags/control/Taxonomy/Taxonomy.js
+++ b/src/tags/control/Taxonomy/Taxonomy.js
@@ -339,6 +339,7 @@ const Model = types
 
       path?.forEach(p => url.searchParams.append('path', p));
 
+
       try {
         const res = yield fetch(url);
         const dataRaw = yield res.json();
@@ -355,6 +356,10 @@ const Model = types
         });
         const items = convert(data, prefix);
 
+        res.catch(err => {
+          self.setError(err);
+        });
+
         if (path) {
           item.children = items;
           self._items = [...self._items];
@@ -362,10 +367,7 @@ const Model = types
           self._items = items;
         }
       } catch (err) {
-        const message = messages.ERR_LOADING_HTTP({ attr: 'apiUrl', error: err, url:self.apiurl });
-
-        console.error(err);
-        self.annotationStore.addErrors([errorBuilder.generalError(message)]);
+        self.setError(err);
       }
 
       self.loading = false;
@@ -399,7 +401,13 @@ const Model = types
 
       self.loading = false;
     },
+    setError(err) {
+      const message = messages.ERR_LOADING_HTTP({ attr: 'apiUrl', error: String(err), url:self.apiurl });
 
+      self.annotationStore.addErrors([errorBuilder.generalError(message)]);
+
+      console.error(err);
+    },
     requiredModal() {
       Infomodal.warning(self.requiredmessage || `Taxonomy "${self.name}" is required.`);
     },


### PR DESCRIPTION
### PR fulfills these requirements
- [x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [x] Frontend



### Describe the reason for change
The app is not using the default message error box, It's showing a modal box blocking all the UI when it shows



#### What does this fix?
It's being changed the way that the error is being shown from the modal box that is blocking the UI to the default message error box in red that hide the tags and just show the error detailed.



#### What libraries were added/updated?
none



#### Does this change affect performance?
no


#### Does this change affect security?
no



#### What alternative approaches were there?
no


#### What feature flags were used to cover this change?
fflag_feat_front_lsdv_5451_async_taxonomy_110823_short



### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [x] No
- [ ] Not sure (briefly explain the situation below)



### What level of testing was included in the change?
_(check all that apply)_
- [ ] e2e
- [ ] integration
- [ ] unit

