### PR TITLE
feat: LEAP-235: Use selected items with full info

### DIFF
--- a/src/components/NewTaxonomy/NewTaxonomy.tsx
+++ b/src/components/NewTaxonomy/NewTaxonomy.tsx
@@ -128,6 +128,7 @@ const NewTaxonomy = ({
     <TreeSelect
       treeData={treeData}
       value={value}
+      labelInValue={true}
       onChange={items => onChange(null, items.map(item => item.value.split(separator)))}
       loadData={loadData}
       treeCheckable

--- a/src/components/NewTaxonomy/NewTaxonomy.tsx
+++ b/src/components/NewTaxonomy/NewTaxonomy.tsx
@@ -40,9 +40,14 @@ type TaxonomyOptions = {
   placeholder?: string,
 };
 
+type SelectedItem = {
+  label: string,
+  value: string,
+}[];
+
 type TaxonomyProps = {
   items: TaxonomyItem[],
-  selected: TaxonomyPath[],
+  selected: SelectedItem[],
   onChange: (node: any, selected: TaxonomyPath[]) => any,
   onLoadData?: (item: TaxonomyPath) => any,
   onAddLabel?: onAddLabelCallback,
@@ -114,7 +119,11 @@ const NewTaxonomy = ({
   const style = { minWidth: options.minWidth ?? 200, maxWidth: options.maxWidth };
   const dropdownWidth = options.dropdownWidth === undefined ? true : +options.dropdownWidth;
   const maxUsagesReached = !!options.maxUsages && selected.length >= options.maxUsages;
-  const value = selected.map(path => path.join(separator));
+  const value = selected.map(path => path.map(p => p.value).join(separator));
+  const displayed = selected.map(path => ({
+    value: path.map(p => p.value).join(separator),
+    label: options.showFullPath ? path.map(p => p.label).join(separator) : path.at(-1).label,
+  }));
 
   useEffect(() => {
     setTreeData(convert(items, { ...options, maxUsagesReached }, value));
@@ -127,7 +136,7 @@ const NewTaxonomy = ({
   return (
     <TreeSelect
       treeData={treeData}
-      value={value}
+      value={displayed}
       labelInValue={true}
       onChange={items => onChange(null, items.map(item => item.value.split(separator)))}
       loadData={loadData}

--- a/src/tags/control/Taxonomy/Taxonomy.js
+++ b/src/tags/control/Taxonomy/Taxonomy.js
@@ -37,6 +37,17 @@ import messages from '../../../utils/messages';
 import { errorBuilder } from '../../../core/DataValidator/ConfigValidator';
 
 /**
+ * @typedef TaxonomyItem
+ * @property {string} label
+ * @property {string[]} path
+ * @property {number} depth
+ * @property {string} [hint]
+ * @property {string} [color]
+ * @property {TaxonomyItem[]} [children]
+ * @property {string} [alias]
+ */
+
+/**
  * The `Taxonomy` tag is used to create one or more hierarchical classifications, storing both choice selections and their ancestors in the results. Use for nested classification tasks with the `Choice` tag.
  *
  * Use with the following data types: audio, image, HTML, paragraphs, text, time series, video.
@@ -283,6 +294,25 @@ const Model = types
       }
 
       return fromConfig;
+    },
+
+    get selectedItems() {
+      const full = self.selected.map(path => {
+        /** @type {TaxonomyItem[]} items */
+        let items = self.items;
+        const levels = [];
+
+        for (const value of path) {
+          const item = items.find(item => item.path.at(-1) === value);
+
+          levels.push({ label: item?.label ?? value, value });
+          items = item?.children ?? [];
+        }
+
+        return levels;
+      });
+
+      return full;
     },
 
     get defaultChildType() {
@@ -575,7 +605,7 @@ const HtxTaxonomy = observer(({ item }) => {
       {isFF(FF_TAXONOMY_ASYNC) ? (
         <NewTaxonomy
           items={item.items}
-          selected={item.selected}
+          selected={item.selectedItems}
           onChange={item.onChange}
           onLoadData={item.loadItems}
           onAddLabel={item.userLabels && item.onAddLabel}

--- a/tests/functional/data/control_tags/taxonomy.ts
+++ b/tests/functional/data/control_tags/taxonomy.ts
@@ -70,14 +70,12 @@ export const taxonomyConfig = `<View>
   </Taxonomy>
 </View>`;
 export const taxonomyConfigWithMaxUsages = `<View>
-  <View>
   <Text name="text" value="$text"/>
   <Taxonomy name="taxonomy" toName="text" maxUsages="1">
     <Choice value="Archaea" />
     <Choice value="Bacteria" />
     <Choice value="Eukarya" />
   </Taxonomy>
-</View>
 </View>`;
 
 export const dynamicData = {
@@ -89,10 +87,61 @@ export const dynamicData = {
   ],
 };
 
+export const taxonomyDataWithSimilarAliases = {
+  text: 'This text exists for no reason',
+  items: [
+    { value: 'Book 1', alias: '1', children: [
+      { value: 'Chapter 1', alias: '1' },
+      { value: 'Chapter 2', alias: '2', children: [
+        { value: 'Section 2.1', alias: '1' },
+        { value: 'Section 2.2', alias: '2' },
+        { value: 'Section 2.3', alias: '3' },
+      ] },
+      { value: 'Chapter 3', alias: '3', children: [
+        { value: 'Section 3.1', alias: '1' },
+        { value: 'Section 3.2', alias: '2' },
+        { value: 'Section 3.3', alias: '3' },
+      ] },
+    ] },
+    { value: 'Book 2', alias: '2', children: [
+      { value: 'Chapter 1', alias: '1' },
+      { value: 'Chapter 2', alias: '2', children: [
+        { value: 'Section 2.1', alias: '1' },
+        { value: 'Section 2.2', alias: '2' },
+        { value: 'Section 2.3', alias: '3' },
+      ] },
+    ] },
+    { value: 'Book 3', alias: '3' },
+  ],
+};
+
+export const taxonomyResultWithSimilarAliases = {
+  'id': 'aliased',
+  'type': 'taxonomy',
+  'value': {
+    'taxonomy': [['1', '2', '1']],
+  },
+  'to_name': 'text',
+  'from_name': 'choices',
+};
+
 export const dynamicTaxonomyConfig = `<View>
-  <Text name="text"/>
-  <Taxonomy name="choices" toName="text" value="$items">
-  </Taxonomy>
+  <Text name="text" value="$text"/>
+  <Taxonomy name="choices" toName="text" value="$items" showFullPath="true"/>
+</View>`;
+
+
+type TaxonomyOptions = {
+  showFullPath?: boolean,
+};
+export const buildDynamicTaxonomyConfig = (options: TaxonomyOptions) => `<View>
+  <Text name="text" value="$text"/>
+  <Taxonomy
+    name="choices"
+    toName="text"
+    value="$items"
+    showFullPath="${JSON.stringify(options.showFullPath ?? false)}"
+  />
 </View>`;
 
 export const taxonomyResultWithAlias = {

--- a/tests/functional/specs/control_tags/taxonomy.cy.ts
+++ b/tests/functional/specs/control_tags/taxonomy.cy.ts
@@ -147,7 +147,7 @@ Object.entries(taxonomies).forEach(([title, Taxonomy]) => {
     }
   });
 
-  describe.only('Control Tags - Taxonomy - showFullPath', () => {
+  describe('Control Tags - Taxonomy - showFullPath', () => {
     // Old Taxonomy has bugs in displaying equal aliases
     if (!Taxonomy.isNew) return;
 

--- a/tests/functional/specs/control_tags/taxonomy.cy.ts
+++ b/tests/functional/specs/control_tags/taxonomy.cy.ts
@@ -1,13 +1,16 @@
 import { LabelStudio, Tooltip } from '@heartexlabs/ls-test/helpers/LSF/index';
 import { useTaxonomy } from '@heartexlabs/ls-test/helpers/LSF';
 import {
+  buildDynamicTaxonomyConfig,
   dataWithPrediction,
   dynamicData,
   dynamicTaxonomyConfig,
   simpleData,
   taxonomyConfig,
   taxonomyConfigWithMaxUsages,
-  taxonomyResultWithAlias
+  taxonomyDataWithSimilarAliases,
+  taxonomyResultWithAlias,
+  taxonomyResultWithSimilarAliases
 } from '../../data/control_tags/taxonomy';
 import {
   FF_DEV_2007,
@@ -134,6 +137,7 @@ Object.entries(taxonomies).forEach(([title, Taxonomy]) => {
           });
   
           init(config, data);
+          // create new annotation and check that preselected choices are selected already
           cy.get('.lsf-annotations-list').click();
           cy.get('.lsf-annotations-list__create').click();
           Taxonomy.open();
@@ -141,5 +145,31 @@ Object.entries(taxonomies).forEach(([title, Taxonomy]) => {
         });
       }
     }
+  });
+
+  describe.only('Control Tags - Taxonomy - showFullPath', () => {
+    // Old Taxonomy has bugs in displaying equal aliases
+    if (!Taxonomy.isNew) return;
+
+    it('should show full path with true', () => {
+      LabelStudio.params()
+        .config(buildDynamicTaxonomyConfig({ showFullPath: true }))
+        .data(taxonomyDataWithSimilarAliases)
+        .withResult([taxonomyResultWithSimilarAliases])
+        .init();
+
+      Taxonomy.hasSelected('Book 1 / Chapter 2 / Section 2.1');
+    });
+
+    it('should show only last item with false', () => {
+      LabelStudio.params()
+        .config(buildDynamicTaxonomyConfig({ showFullPath: false }))
+        .data(taxonomyDataWithSimilarAliases)
+        .withResult([taxonomyResultWithSimilarAliases])
+        .init();
+
+      Taxonomy.hasSelected('Section 2.1');
+      Taxonomy.hasNoSelected('Book 1 / Chapter 2 / Section 2.1');
+    });
   });
 });


### PR DESCRIPTION
Cache both alias and value for selected items in Taxonomy. This leads to couple of fixes and improvements:
- correct showFullPath
- faster visibility checks
- tidy code

`selected` is managed only in Taxonomy.js in `onChange()` and `needsUpdate()` methods, then used mostly to detect its length, and to pass to Taxonomy component (new or old).

Full selected items depend on list of selected values and list of already loaded items.

### PR fulfills these requirements
- [ ] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [ ] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [ ] Frontend



### Describe the reason for change
_(link to issue, supportive screenshots etc.)_



#### What does this fix?
_(if this is a bug fix)_



#### What is the new behavior?
_(if this is a breaking or feature change)_



#### What is the current behavior?
_(if this is a breaking or feature change)_



#### What libraries were added/updated?
_(list all with version changes)_



#### Does this change affect performance?
_(if so describe the impacts positive or negative)_



#### Does this change affect security?
_(if so describe the impacts positive or negative)_



#### What alternative approaches were there?
_(briefly list any if applicable)_



#### What feature flags were used to cover this change?
_(briefly list any if applicable)_



### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [ ] No
- [ ] Not sure (briefly explain the situation below)



### What level of testing was included in the change?
_(check all that apply)_
- [ ] e2e
- [ ] integration
- [ ] unit



### Which logical domain(s) does this change affect?
_(for bug fixes/features, be as precise as possible. ex. Authentication, Annotation History, Review Stream etc.)_
