### PR TITLE
fix: LEAP-295: Fix error styles in LS modals

### DIFF
--- a/src/components/ErrorMessage/ErrorMessage.module.scss
+++ b/src/components/ErrorMessage/ErrorMessage.module.scss
@@ -6,6 +6,7 @@
   color: rgb(119, 27, 4);
   border: 1px solid rgb(230, 138, 110);
   background-color: rgb(255, 193, 174);
+  white-space: normal;
 
   & + & {
     margin: 0 0 16px; // in case we are in flex container, where margins don't collapse


### PR DESCRIPTION
Create Project modal's preview had broken styles

### PR fulfills these requirements
- [x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)


#### What does this fix?
Overrides styles from LS modal (it has `white-space: pre-wrap` for some reason)



### Does this PR introduce a breaking change?
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [x] No
- [ ] Not sure (briefly explain the situation below)