### PR TITLE
fix: LEAP-299: Show spinner while taxonomy's loading

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -94,7 +94,7 @@ jobs:
         run: |
           set -euo pipefail
           cd e2e
-          yarn run test:ci ${{ steps.cpu-info.outputs.cores-count }} --debug --verbose
+          yarn run test:ci ${{ steps.cpu-info.outputs.cores-count }}
 
       - name: "Upload e2e output" 
         uses: ./.github/actions/upload-artifact

--- a/src/tags/control/Taxonomy/Taxonomy.js
+++ b/src/tags/control/Taxonomy/Taxonomy.js
@@ -587,6 +587,12 @@ const TaxonomyModel = types.compose('TaxonomyModel',
 );
 
 const HtxTaxonomy = observer(({ item }) => {
+  // literal "taxonomy" class name is for external styling
+  const className = [
+    styles.taxonomy,
+    'taxonomy',
+    isFF(FF_TAXONOMY_ASYNC) ? styles.taxonomy__new : '',
+  ].filter(Boolean).join(' ');
   const visibleStyle = item.perRegionVisible() && item.isVisible ? {} : { display: 'none' };
   const options = {
     showFullPath: item.showfullpath,
@@ -600,9 +606,18 @@ const HtxTaxonomy = observer(({ item }) => {
     canRemoveItems: item.canRemoveItems,
   };
 
+  if (item.loading && isFF(FF_DEV_3617)) {
+    return (
+      <div className={className} style={visibleStyle}>
+        <div className={styles.taxonomy__loading}>
+          <Spin size="small"/>
+        </div>
+      </div>
+    );
+  }
+
   return (
-    // @todo use BEM class names + literal "taxonomy" for external styling
-    <div className={[styles.taxonomy, 'taxonomy'].join(' ')} style={{ ...visibleStyle }}>
+    <div className={className} style={visibleStyle}>
       {(isFF(FF_TAXONOMY_ASYNC) && !item.legacy) ? (
         <NewTaxonomy
           items={item.items}
@@ -615,21 +630,15 @@ const HtxTaxonomy = observer(({ item }) => {
           isEditable={!item.isReadOnly()}
         />
       ) : (
-        item.loading && isFF(FF_DEV_3617) ? (
-          <div className={styles.taxonomy__loading}>
-            <Spin size="small"/>
-          </div>
-        ) : (
-          <Taxonomy
-            items={item.items}
-            selected={item.selected}
-            onChange={item.onChange}
-            onAddLabel={item.userLabels && item.onAddLabel}
-            onDeleteLabel={item.userLabels && item.onDeleteLabel}
-            options={options}
-            isEditable={!item.isReadOnly()}
-          />
-        )
+        <Taxonomy
+          items={item.items}
+          selected={item.selected}
+          onChange={item.onChange}
+          onAddLabel={item.userLabels && item.onAddLabel}
+          onDeleteLabel={item.userLabels && item.onDeleteLabel}
+          options={options}
+          isEditable={!item.isReadOnly()}
+        />
       )}
     </div>
   );

--- a/src/tags/control/Taxonomy/Taxonomy.js
+++ b/src/tags/control/Taxonomy/Taxonomy.js
@@ -606,7 +606,12 @@ const HtxTaxonomy = observer(({ item }) => {
     canRemoveItems: item.canRemoveItems,
   };
 
-  if (item.loading && isFF(FF_DEV_3617)) {
+  // without full api there will be just one initial loading;
+  // with full api we should not block UI with spinner on nested requests —
+  // they are indicated by loading icon on the item itself
+  const firstLoad = item.isLoadedByApi ? !item.items.length : true;
+
+  if (item.loading && isFF(FF_DEV_3617) && firstLoad) {
     return (
       <div className={className} style={visibleStyle}>
         <div className={styles.taxonomy__loading}>

--- a/src/tags/control/Taxonomy/Taxonomy.styl
+++ b/src/tags/control/Taxonomy/Taxonomy.styl
@@ -19,3 +19,7 @@
 
     & > div > span
       display block
+
+  &__new &__loading
+    margin-top 0
+    height 31px

--- a/tests/functional/package.json
+++ b/tests/functional/package.json
@@ -18,7 +18,7 @@
     "cvg:summary": "nyc report --temp-dir=.nyc_output --reporter=text-summary --cwd=. --exclude-after-remap false"
   },
   "dependencies": {
-    "@heartexlabs/ls-test": "git+ssh://git@github.com/heartexlabs/ls-frontend-test#b4c8edbe8f15ac1d6ad0d8bb7bd9aede14dc8e06"
+    "@heartexlabs/ls-test": "git+ssh://git@github.com/heartexlabs/ls-frontend-test#92d2d556d2d4499b321b575359026267da19a9fb"
   },
   "devDependencies": {
     "ts-loader": "^9.4.2",

--- a/tests/functional/yarn.lock
+++ b/tests/functional/yarn.lock
@@ -264,9 +264,9 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
 
-"@heartexlabs/ls-test@git+ssh://git@github.com/heartexlabs/ls-frontend-test#b4c8edbe8f15ac1d6ad0d8bb7bd9aede14dc8e06":
+"@heartexlabs/ls-test@git+ssh://git@github.com/heartexlabs/ls-frontend-test#92d2d556d2d4499b321b575359026267da19a9fb":
   version "1.0.8"
-  resolved "git+ssh://git@github.com/heartexlabs/ls-frontend-test#b4c8edbe8f15ac1d6ad0d8bb7bd9aede14dc8e06"
+  resolved "git+ssh://git@github.com/heartexlabs/ls-frontend-test#92d2d556d2d4499b321b575359026267da19a9fb"
   dependencies:
     "@cypress/code-coverage" "^3.10.0"
     "@cypress/webpack-preprocessor" "^5.17.0"


### PR DESCRIPTION
We combine two things:
- flag we already have inside taxonomy (`loading`)
- spinner we already use for old taxonomy

and display spinner when flag is true.

Also styles should be adjusted to match the height of taxonomy to not jump when it's loaded.

### PR fulfills these requirements
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



### Describe the reason for change
Currently taxonomy displays No Data dropdown stub while loading. And this loading state is not indicated anyhow, confusing the user.



### This change affects (describe how if yes)
- [ ] Performance
- [ ] Security
- [x] UX — improves loading state by indicating it clearly



### What alternative approaches were there?
To modify current empty state to change phrasing. But spinner is more clear and we already have it.
The downside is that selected items are only visible after taxonomy is loaded.



### What feature flags were used to cover this change?
`fflag_feat_front_lsdv_5451_async_taxonomy_110823_short`



### Does this PR introduce a breaking change?
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [x] No
- [ ] Not sure (briefly explain the situation below)



### What level of testing was included in the change?
- [ ] e2e
- [ ] integration
- [ ] unit



### Which logical domain(s) does this change affect?
Taxonomy
