### PR TITLE
feat: LEAP-336: Collapsible cards in Ranker

### DIFF
--- a/src/components/Ranker/Column.tsx
+++ b/src/components/Ranker/Column.tsx
@@ -13,23 +13,37 @@ interface ColumnProps {
   readonly?: boolean;
 }
 
-/*
- * defines a column component used by the DragDropBoard component. Each column contains items
- * that can be reordered by dragging.
+/**
+ * Separate component to incapsulate all the logic related to collapsible column titles.
  */
-
-const Column = (props: ColumnProps) => {
-  const { column, items, readonly } = props;
-  const [collapsedMap, toggleCollapsed] = useContext(CollapsedContext);
+const CollapsibleColumnTitle = ({ items, title }: { items: InputItem[], title: string }) => {
+  const [, collapsedMap, toggleCollapsed] = useContext(CollapsedContext);
   const collapsed = items.every(item => collapsedMap[item.id]);
   const toggle = () => toggleCollapsed(items.map(item => item.id), !collapsed);
 
   return (
+    <h1 className={[styles.columnTitle, collapsed ? styles.collapsed : styles.expanded].join(' ')}>
+      {title}
+      <button onClick={toggle}><span></span></button>
+    </h1>
+  );
+};
+
+/**
+ * Defines a column component used by the DragDropBoard component. Each column contains items
+ * that can be reordered by dragging.
+ */
+const Column = (props: ColumnProps) => {
+  const { column, items, readonly } = props;
+  const [collapsible] = useContext(CollapsedContext);
+
+  const title = collapsible
+    ? <CollapsibleColumnTitle items={items} title={column.title} />
+    : <h1 className={styles.columnTitle}>{column.title}</h1>;
+
+  return (
     <div className={[styles.column, 'htx-ranker-column'].join(' ')}>
-      <h1 className={[styles.columnTitle, collapsed ? styles.collapsed : ''].join(' ')}>
-        {column.title}
-        <button onClick={toggle}><span></span></button>
-      </h1>
+      {title}
       <StrictModeDroppable droppableId={column.id}>
         {provided => (
           <div ref={provided.innerRef} {...provided.droppableProps} className={styles.dropArea}>

--- a/src/components/Ranker/Column.tsx
+++ b/src/components/Ranker/Column.tsx
@@ -1,6 +1,9 @@
-import Item from './Item';
-import { StrictModeDroppable } from './StrictModeDroppable';
+import { useContext } from 'react';
+
 import { InputItem, NewColumnData } from './createData';
+import Item from './Item';
+import { CollapsedContext } from './Ranker';
+import { StrictModeDroppable } from './StrictModeDroppable';
 
 import styles from './Ranker.module.scss';
 
@@ -17,10 +20,16 @@ interface ColumnProps {
 
 const Column = (props: ColumnProps) => {
   const { column, items, readonly } = props;
+  const [collapsedMap, toggleCollapsed] = useContext(CollapsedContext);
+  const collapsed = items.every(item => collapsedMap[item.id]);
+  const toggle = () => toggleCollapsed(items.map(item => item.id), !collapsed);
 
   return (
     <div className={[styles.column, 'htx-ranker-column'].join(' ')}>
-      <h1>{column.title}</h1>
+      <h1 className={[styles.columnTitle, collapsed ? styles.collapsed : ''].join(' ')}>
+        {column.title}
+        <button onClick={toggle}><span></span></button>
+      </h1>
       <StrictModeDroppable droppableId={column.id}>
         {provided => (
           <div ref={provided.innerRef} {...provided.droppableProps} className={styles.dropArea}>

--- a/src/components/Ranker/Item.tsx
+++ b/src/components/Ranker/Item.tsx
@@ -22,9 +22,14 @@ const Item = (props: ItemProps) => {
 
   // @todo document html parameter later after proper tests
   const html = useMemo(() => item.html ? sanitizeHtml(item.html) : '', [item.html]);
-  const [collapsedMap, toggleCollapsed] = useContext(CollapsedContext);
+  const [collapsible, collapsedMap, toggleCollapsed] = useContext(CollapsedContext);
   const collapsed = collapsedMap[item.id] ?? false;
-  const toggle = () => toggleCollapsed(item.id, !collapsed);
+  const toggle = collapsible
+    ? () => toggleCollapsed(item.id, !collapsed)
+    : undefined;
+  const classNames = [styles.item, 'htx-ranker-item'];
+
+  if (collapsible) classNames.push(collapsed ? styles.collapsed : styles.expanded);
 
   return (
     <Draggable draggableId={item.id} index={index} isDragDisabled={readonly}>
@@ -34,7 +39,7 @@ const Item = (props: ItemProps) => {
             {...provided.draggableProps}
             {...provided.dragHandleProps}
             style={{ ...provided.draggableProps.style }}
-            className={[styles.item, collapsed ? styles.collapsed : '', 'htx-ranker-item'].join(' ')}
+            className={classNames.join(' ')}
             ref={provided.innerRef}
             data-ranker-id={item.id}
           >

--- a/src/components/Ranker/Item.tsx
+++ b/src/components/Ranker/Item.tsx
@@ -4,6 +4,7 @@ import { Draggable } from 'react-beautiful-dnd';
 import { sanitizeHtml } from '../../utils/html';
 import { InputItem } from './createData';
 import { CollapsedContext } from './Ranker';
+
 import styles from './Ranker.module.scss';
 
 interface ItemProps {

--- a/src/components/Ranker/Item.tsx
+++ b/src/components/Ranker/Item.tsx
@@ -1,8 +1,9 @@
-import { useMemo } from 'react';
+import { useContext, useMemo } from 'react';
 import { Draggable } from 'react-beautiful-dnd';
 
 import { sanitizeHtml } from '../../utils/html';
 import { InputItem } from './createData';
+import { CollapsedContext } from './Ranker';
 import styles from './Ranker.module.scss';
 
 interface ItemProps {
@@ -20,6 +21,9 @@ const Item = (props: ItemProps) => {
 
   // @todo document html parameter later after proper tests
   const html = useMemo(() => item.html ? sanitizeHtml(item.html) : '', [item.html]);
+  const [collapsedMap, toggleCollapsed] = useContext(CollapsedContext);
+  const collapsed = collapsedMap[item.id] ?? false;
+  const toggle = () => toggleCollapsed(item.id, !collapsed);
 
   return (
     <Draggable draggableId={item.id} index={index} isDragDisabled={readonly}>
@@ -33,10 +37,14 @@ const Item = (props: ItemProps) => {
             ref={provided.innerRef}
             data-ranker-id={item.id}
           >
-            {item.title && <h3 className={styles.itemLine}>{item.title}</h3>}
-            {item.body && <p className={styles.itemLine}>{item.body}</p>}
-            {item.html && <p className={styles.itemLine} dangerouslySetInnerHTML={{ __html: html }} />}
-            <p className={styles.itemLine}>{item.id}</p>
+            {item.title && <h3 className={styles.itemLine} onClick={toggle}>{item.title}</h3>}
+            {!collapsed && (
+              <>
+                {item.body && <p className={styles.itemLine}>{item.body}</p>}
+                {item.html && <p className={styles.itemLine} dangerouslySetInnerHTML={{ __html: html }} />}
+                <p className={styles.itemLine}>{item.id}</p>
+              </>
+            )}
           </div>
         );
       }}

--- a/src/components/Ranker/Item.tsx
+++ b/src/components/Ranker/Item.tsx
@@ -33,18 +33,14 @@ const Item = (props: ItemProps) => {
             {...provided.draggableProps}
             {...provided.dragHandleProps}
             style={{ ...provided.draggableProps.style }}
-            className={[styles.item, 'htx-ranker-item'].join(' ')}
+            className={[styles.item, collapsed ? styles.collapsed : '', 'htx-ranker-item'].join(' ')}
             ref={provided.innerRef}
             data-ranker-id={item.id}
           >
-            {item.title && <h3 className={styles.itemLine} onClick={toggle}>{item.title}</h3>}
-            {!collapsed && (
-              <>
-                {item.body && <p className={styles.itemLine}>{item.body}</p>}
-                {item.html && <p className={styles.itemLine} dangerouslySetInnerHTML={{ __html: html }} />}
-                <p className={styles.itemLine}>{item.id}</p>
-              </>
-            )}
+            {item.title && <h3 className={styles.itemTitle} onClick={toggle}>{item.title}</h3>}
+            {item.body && <p className={styles.itemLine}>{item.body}</p>}
+            {item.html && <p className={styles.itemLine} dangerouslySetInnerHTML={{ __html: html }} />}
+            <p className={styles.itemLine}>{item.id}</p>
           </div>
         );
       }}

--- a/src/components/Ranker/Ranker.module.scss
+++ b/src/components/Ranker/Ranker.module.scss
@@ -40,10 +40,10 @@
       cursor: pointer;
     }
 
-    button span::after {
+    &.expanded button span::after {
       content: '△';
     }
-    button:hover span::after {
+    &.expanded button:hover span::after {
       content: '▲';
     }
     &.collapsed button span::after {
@@ -80,15 +80,16 @@
   display: none;
 }
 
-.itemTitle::after {
+.item.expanded > .itemTitle::after {
   content: '△';
   margin-left: auto;
 }
-.itemTitle:hover::after {
+.item.expanded > .itemTitle:hover::after {
   content: '▲';
 }
 .item.collapsed > .itemTitle::after {
   content: '▽';
+  margin-left: auto;
 }
 .item.collapsed > .itemTitle:hover::after {
   content: '▼';

--- a/src/components/Ranker/Ranker.module.scss
+++ b/src/components/Ranker/Ranker.module.scss
@@ -16,7 +16,7 @@
   border-radius: 2px;
   display: flex;
   flex-direction: column;
-  align-items: center;
+  align-items: stretch;
   overflow-y: scroll;
 
   [data-rbd-droppable-id] {
@@ -64,7 +64,6 @@
   border-radius: 2px;
   background-color: #f5f5f5;
   color: black;
-  max-width: 400px;
 }
 
 .itemLine {

--- a/src/components/Ranker/Ranker.module.scss
+++ b/src/components/Ranker/Ranker.module.scss
@@ -27,6 +27,32 @@
   & + & {
     margin-left: var(--ranker-gap);
   }
+
+  .columnTitle {
+    display: flex;
+
+    button {
+      margin-left: auto;
+      background: none;
+      border: none;
+      font-size: 0.75em;
+      width: 2em;
+      cursor: pointer;
+    }
+
+    button span::after {
+      content: '△';
+    }
+    button:hover span::after {
+      content: '▲';
+    }
+    &.collapsed button span::after {
+      content: '▽';
+    }
+    &.collapsed button:hover span::after {
+      content: '▼';
+    }
+  }
 }
 
 .item {

--- a/src/components/Ranker/Ranker.module.scss
+++ b/src/components/Ranker/Ranker.module.scss
@@ -44,6 +44,29 @@
 .itemLine {
   margin: 0;
 }
+.itemTitle {
+  margin: 0;
+  display: flex;
+  cursor: pointer;
+}
+
+.item.collapsed > *:not(.itemTitle) {
+  display: none;
+}
+
+.itemTitle::after {
+  content: '△';
+  margin-left: auto;
+}
+.itemTitle:hover::after {
+  content: '▲';
+}
+.item.collapsed > .itemTitle::after {
+  content: '▽';
+}
+.item.collapsed > .itemTitle:hover::after {
+  content: '▼';
+}
 
 .dropArea {
   min-height: 50%;

--- a/src/components/Ranker/Ranker.tsx
+++ b/src/components/Ranker/Ranker.tsx
@@ -12,7 +12,7 @@ interface BoardProps {
   readonly?: boolean;
 }
 type CollapsedMap = Record<string, boolean>;
-type CollapsedContextType = React.Context<[CollapsedMap, (id: string, value: boolean) => void]>;
+type CollapsedContextType = React.Context<[CollapsedMap, (idOrIds: string | string[], value: boolean) => void]>;
 
 const CollapsedContext: CollapsedContextType = createContext([{}, (_id, _value) => {}]);
 
@@ -20,8 +20,11 @@ const CollapsedContext: CollapsedContextType = createContext([{}, (_id, _value) 
 const Ranker = ({ inputData, handleChange, readonly }: BoardProps) => {
   const [data, setData] = useState(inputData);
   const [collapsed, setCollapsed] = useState<CollapsedMap>({});
-  const toggleCollapsed = useCallback((id: string, value: boolean) => {
-    setCollapsed(c => ({ ...c, [id]: value }));
+  const toggleCollapsed = useCallback((idOrIds: string | string[], value: boolean) => {
+    const ids = Array.isArray(idOrIds) ? idOrIds : [idOrIds];
+    const values = ids.reduce((acc, id) => ({ ...acc, [id]: value }), {});
+
+    setCollapsed(c => ({ ...c, ...values }));
   }, []);
 
   // Update data when inputData changes

--- a/src/components/Ranker/Ranker.tsx
+++ b/src/components/Ranker/Ranker.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { createContext, useCallback, useEffect, useState } from 'react';
 import { DragDropContext, DropResult } from 'react-beautiful-dnd';
 
 import Column from './Column';
@@ -11,10 +11,18 @@ interface BoardProps {
   handleChange?: (ids: Record<string, string[]>) => void;
   readonly?: boolean;
 }
+type CollapsedMap = Record<string, boolean>;
+type CollapsedContextType = React.Context<[CollapsedMap, (id: string, value: boolean) => void]>;
+
+const CollapsedContext: CollapsedContextType = createContext([{}, (_id, _value) => {}]);
 
 // Component for a drag and drop board with 1+ columns
 const Ranker = ({ inputData, handleChange, readonly }: BoardProps) => {
   const [data, setData] = useState(inputData);
+  const [collapsed, setCollapsed] = useState<CollapsedMap>({});
+  const toggleCollapsed = useCallback((id: string, value: boolean) => {
+    setCollapsed(c => ({ ...c, [id]: value }));
+  }, []);
 
   // Update data when inputData changes
   useEffect(() => {
@@ -86,7 +94,7 @@ const Ranker = ({ inputData, handleChange, readonly }: BoardProps) => {
   };
 
   return (
-    <>
+    <CollapsedContext.Provider value={[collapsed, toggleCollapsed]}>
       <DragDropContext onDragEnd={handleDragEnd}>
         <div className={styles.board}>
           <>
@@ -98,8 +106,9 @@ const Ranker = ({ inputData, handleChange, readonly }: BoardProps) => {
           </>
         </div>
       </DragDropContext>
-    </>
+    </CollapsedContext.Provider>
   );
 };
 
+export { CollapsedContext };
 export default Ranker;

--- a/src/tags/control/Ranker.js
+++ b/src/tags/control/Ranker.js
@@ -76,6 +76,7 @@ const Model = types
   .model({
     type: 'ranker',
     toname: types.maybeNull(types.string),
+    collapsible: types.optional(types.boolean, true),
 
     // @todo allow Views inside: ['bucket', 'view']
     children: Types.unionArray(['bucket']),
@@ -200,7 +201,12 @@ const HtxRanker = inject('store')(
     if (!data) return null;
 
     return (
-      <Ranker inputData={data} handleChange={item.updateResult} readonly={item.isReadOnly()} />
+      <Ranker
+        inputData={data}
+        handleChange={item.updateResult}
+        readonly={item.isReadOnly()}
+        collapsible={item.collapsible}
+      />
     );
   }),
 );


### PR DESCRIPTION
Allow to collapse and expand cards for easy interactions. With collapsed cards user can see lot of items together with makes rearrangement easier.

Collapsed/expanded states are indicated by ASCII triangles (△/▽ and ▲/▼ for hovered state) used in css to change only class names, not the content and to keep indicators in one place.

Collapse is desirable action so column is treated as expanded when at least one item is expanded. This allows to collapse all items in any state by one click.

New hidden parameter added to `Ranker`: `collapsible` with default true to allow to disable this functionality if it's not needed for any reason.

### PR fulfills these requirements
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)

#### What libraries were added/updated?
none

#### Does this change affect performance?
nope

#### Does this change affect security?
nope

#### What alternative approaches were there?
Cards can be made hidden with animation to not change the content inside, but this will require calculations of their height.

#### What feature flags were used to cover this change?
none yet

### Does this PR introduce a breaking change?
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [x] No
- [ ] Not sure (briefly explain the situation below)

### What level of testing was included in the change?
_(check all that apply)_
- [ ] e2e
- [ ] integration
- [ ] unit

### Which logical domain(s) does this change affect?
Ranker

<img width="755" alt="Screenshot 2023-11-07 at 16 14 40" src="https://github.com/HumanSignal/label-studio-frontend/assets/1607227/0501513d-c7f9-4185-abe1-303b99a9c159">
