### PR TITLE
ci: New PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 Main description of what's done here, shortly, with reasoning, references, thoughts and ideas for better understanding.
-This text is intended to be removed and replaced with actual description. Other items can also be removed or edited if not relevant. If any of following items require more description, it should also go in this block.
-Please, read all items and make an action every time to create more conscious PR. Thanks!
+This text is intended to be replaced with actual description. Other items should be filled in or removed if not relevant. If any of following items require more description, it should also go in this block.
+Please read all items and ensure each section has been **filled in or removed** to create more consistent pull requests! Thanks!
 
 ### PR fulfills these requirements
 - [ ] Tests for the changes have been added/updated
@@ -9,11 +9,13 @@ Please, read all items and make an action every time to create more conscious PR
 - [ ] Self-reviewed and ran all changes on a local instance
 
 ### Describe the reason for change
-(if it's not clear from description)
+_(if it's not clear from description — otherwise remove section)_
 
 ### What feature flags were used to cover this change?
+_(feature flags created for this pull request or used to cover changes in this pull request)_
 
 ### What alternative approaches were there?
+_(if there are multiple ways to go, describe them and the reasoning for chosing the current way)_
 
 ### This change affects (describe how if yes)
 - [ ] Performance
@@ -32,4 +34,4 @@ Please, read all items and make an action every time to create more conscious PR
 - [ ] unit (jest)
 
 ### Which logical domain(s) does this change affect?
-(comma-separated list like "Taxonomy, Dynamic Children")
+_(comma-separated list like "Taxonomy, Dynamic Children" - if that's not clear from description, otherwise remove section)_

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,80 +1,35 @@
+Main description of what's done here, shortly, with reasoning, references, thoughts and ideas for better understanding.
+This text is intended to be removed and replaced with actual description. Other items can also be removed or edited if not relevant. If any of following items require more description, it should also go in this block.
+Please, read all items and make an action every time to create more conscious PR. Thanks!
+
 ### PR fulfills these requirements
-- [ ] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
-- [ ] Tests for the changes have been added/updated (for bug fixes/features)
-- [ ] Docs have been added/updated (for bug fixes/features)
+- [ ] Tests for the changes have been added/updated
+- [ ] Docs have been added/updated
 - [ ] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
-- [ ] Self-reviewed and ran all changes on a local instance (for bug fixes/features)
-
-
-
-#### Change has impacts in these area(s)
-_(check all that apply)_
-- [ ] Product design
-- [ ] Frontend
-
-
+- [ ] Self-reviewed and ran all changes on a local instance
 
 ### Describe the reason for change
-_(link to issue, supportive screenshots etc.)_
+(if it's not clear from description)
 
+### What feature flags were used to cover this change?
 
+### What alternative approaches were there?
 
-#### What does this fix?
-_(if this is a bug fix)_
-
-
-
-#### What is the new behavior?
-_(if this is a breaking or feature change)_
-
-
-
-#### What is the current behavior?
-_(if this is a breaking or feature change)_
-
-
-
-#### What libraries were added/updated?
-_(list all with version changes)_
-
-
-
-#### Does this change affect performance?
-_(if so describe the impacts positive or negative)_
-
-
-
-#### Does this change affect security?
-_(if so describe the impacts positive or negative)_
-
-
-
-#### What alternative approaches were there?
-_(briefly list any if applicable)_
-
-
-
-#### What feature flags were used to cover this change?
-_(briefly list any if applicable)_
-
-
+### This change affects (describe how if yes)
+- [ ] Performance
+- [ ] Security
+- [ ] UX
 
 ### Does this PR introduce a breaking change?
-_(check only one)_
 - [ ] Yes, and covered entirely by feature flag(s)
 - [ ] Yes, and covered partially by feature flag(s)
 - [ ] No
 - [ ] Not sure (briefly explain the situation below)
 
-
-
 ### What level of testing was included in the change?
-_(check all that apply)_
-- [ ] e2e
-- [ ] integration
-- [ ] unit
-
-
+- [ ] e2e (codecept)
+- [ ] integration (cypress)
+- [ ] unit (jest)
 
 ### Which logical domain(s) does this change affect?
-_(for bug fixes/features, be as precise as possible. ex. Authentication, Annotation History, Review Stream etc.)_
+(comma-separated list like "Taxonomy, Dynamic Children")

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
-Main description of what's done here, shortly, with reasoning, references, thoughts and ideas for better understanding.
-This text is intended to be replaced with actual description. Other items should be filled in or removed if not relevant. If any of following items require more description, it should also go in this block.
-Please read all items and ensure each section has been **filled in or removed** to create more consistent pull requests! Thanks!
+1.) First replace this text with a brief description of what this pull request does. Include reasoning, references, and other thoughts for better understanding.
+2.) Then fill in the items below (adding more description if necessary) or remove them if they aren't relevant. 
+Please read all items and ensure that each section has been **filled in OR removed** to create more consistent PRs! Thank you!
 
 ### PR fulfills these requirements
 - [ ] Tests for the changes have been added/updated
@@ -9,10 +9,10 @@ Please read all items and ensure each section has been **filled in or removed** 
 - [ ] Self-reviewed and ran all changes on a local instance
 
 ### Describe the reason for change
-_(if it's not clear from description — otherwise remove section)_
+_(if it's not clear from main description — otherwise remove this section)_
 
 ### What feature flags were used to cover this change?
-_(feature flags created for this pull request or used to cover changes in this pull request)_
+_(list any feature flags created for this PR or used to cover changes in this PR)_
 
 ### What alternative approaches were there?
 _(if there are multiple ways to go, describe them and the reasoning for chosing the current way)_
@@ -34,4 +34,4 @@ _(if there are multiple ways to go, describe them and the reasoning for chosing 
 - [ ] unit (jest)
 
 ### Which logical domain(s) does this change affect?
-_(comma-separated list like "Taxonomy, Dynamic Children" - if that's not clear from description, otherwise remove section)_
+_(if not already included in the description, add a comma-separated list like "Taxonomy, Dynamic Children")_


### PR DESCRIPTION
Shorter version of our frontend PR template to encourage and help to make more thoughtful description and highlight important nuances of every PR.

### Describe the reason for change
Current PR template usually left (mostly) untouched, because it has lot of items to read and change.