### PR TITLE
Fix: HumanSignal/label-studio#4386: Added tag-selected mode for visibleWhen

### DIFF
--- a/src/mixins/Visibility.js
+++ b/src/mixins/Visibility.js
@@ -55,6 +55,10 @@ const VisibilityMixin = types
 
           'no-region-selected': () => !self.annotation.highlightedNode,
           'choice-unselected': params => !fns['choice-selected'](params),
+          'tag-selected': ({ tagName }) => {
+            const tag = self.annotation.names.get(tagName);
+            return tag.isSelected;
+            },
         };
 
         if (Object.keys(fns).includes(self.visiblewhen)) {

--- a/src/tags/visual/View.js
+++ b/src/tags/visual/View.js
@@ -28,8 +28,8 @@ import { AnnotationMixin } from '../../mixins/AnnotationMixin';
  * @param {block|inline} display
  * @param {string} [style] CSS style string
  * @param {string} [className] - Class name of the CSS style to apply. Use with the Style tag
- * @param {region-selected|choice-selected|no-region-selected|choice-unselected} [visibleWhen] Control visibility of the content. Can also be used with `when*` attributes below to narrow down visibility
- * @param {string} [whenTagName] Use with visibleWhen. Narrow down visibility by tag name. For regions, use the name of the object tag, for choices, use the name of the choices tag
+ * @param {region-selected|choice-selected|no-region-selected|choice-unselected|tag-selected} [visibleWhen] Control visibility of the content. Can also be used with `when*` attributes below to narrow down visibility
+ * @param {string} [whenTagName] Use with visibleWhen. Narrow down visibility by tag name. For regions, use the name of the object tag, for choices, use the name of the choices tag, for tag use the name of the tag
  * @param {string} [whenLabelValue] Use with visibleWhen="region-selected". Narrow down visibility by label value
  * @param {string} [whenChoiceValue] Use with visibleWhen ("choice-selected" or "choice-unselected") and whenTagName, both are required. Narrow down visibility by choice value
  */


### PR DESCRIPTION
### PR fulfills these requirements
- [x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [x ] Docs have been added/updated (for bug fixes/features)
- [x] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [x] Frontend



### Describe the reason for change
As described in HumanSignal/label-studio#4386 in label studio version 1.7.3  `visibleWhen="choice-selected"  whenTagName="name"` worked clicking on the label.

With label studio version > 1.7.3 that does not work any-more.

I realized that the difference was caused by commit 791b7135d7a37db382bae18e473b14ba39bdd966.

I suppose that it was probably an unintended effect in label studio version <= 1.7.3
So I propose to add a new variant for visibleWhen: `visibleWhen="tag-selected"  whenTagName="name"` to have the same behaviour: shows panes clicking on the label.


#### What does this fix?
Fix: HumanSignal/label-studio#4386

Now using `visibleWhen="tag-selected"` the following  labeling interface as follows:

```
<View>
<View>
<Text name="text" value="$text" granularity="word"/>
</View>
<View>
<Labels name="name" toName="text">
<Label value="text_selection" background="red" alias="alias" granularity="word"/>
</Labels>
<View style="display: flex; flex-wrap: wrap;">
<View className="alias" style="margin: 2px;" visibleWhen="tag-selected"  whenTagName="name">
<Choices name="choices" toName="text" choice="multiple" showInLine="true" required="true">
<Choice alias="yes" value="yes" selected="true" />
<Choice alias="no" value="no" />
</Choices>
</View>
</View>
</View>
</View>
```

#### What is the new behavior?
Shows additional panels clicking on the label.

No click:
![image](https://github.com/HumanSignal/label-studio-frontend/assets/983665/4e985a08-5d89-4ebb-998d-338b26593d68)

Click:
![image](https://github.com/HumanSignal/label-studio-frontend/assets/983665/e58feea7-84fa-4750-a201-555c223cd443)


#### What is the current behavior?
`choice-selected` doesn't work like label studio version <= 1.7.3 



#### What libraries were added/updated?
None.



#### Does this change affect performance?
No.



#### Does this change affect security?
No.



#### What alternative approaches were there?
_(briefly list any if applicable)_



#### What feature flags were used to cover this change?
_(briefly list any if applicable)_



### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [x] No
- [ ] Not sure (briefly explain the situation below)



### What level of testing was included in the change?
_(check all that apply)_
- [ ] e2e
- [ ] integration
- [ ] unit



### Which logical domain(s) does this change affect?
_(for bug fixes/features, be as precise as possible. ex. Authentication, Annotation History, Review Stream etc.)_
