### PR TITLE
fix: LEAP-419: Fix brush issues appeared after fixing zoom performance

### DIFF
--- a/e2e/tests/regression-tests/image-ctrl-drawing.test.js
+++ b/e2e/tests/regression-tests/image-ctrl-drawing.test.js
@@ -206,6 +206,9 @@ Scenario('How it works without ctrl', async function({ I, LabelStudio, AtSidebar
   for (const regionPair of regionPairs) {
     const [outerRegion, innerRegion] = regionPair;
 
+    // Brush is not relevant in this case anymore (it will not interact with other regions)
+    if (innerRegion.shape === 'Brush') continue;
+
     LabelStudio.init(params);
     AtImageView.waitForImage();
     AtSidebar.seeRegions(0);

--- a/src/regions/BrushRegion.js
+++ b/src/regions/BrushRegion.js
@@ -18,7 +18,7 @@ import IsReadyMixin from '../mixins/IsReadyMixin';
 import { KonvaRegionMixin } from '../mixins/KonvaRegion';
 import { ImageModel } from '../tags/object/Image';
 import { colorToRGBAArray, rgbArrayToHex } from '../utils/colors';
-import { FF_DEV_3793, FF_DEV_4081, isFF } from '../utils/feature-flags';
+import { FF_DEV_3793, FF_DEV_4081, FF_ZOOM_OPTIM, isFF } from '../utils/feature-flags';
 import { AliveRegion } from './AliveRegion';
 import { RegionWrapper } from './RegionWrapper';
 
@@ -271,6 +271,11 @@ const Model = types
         const ctx = layer.canvas.context;
 
         ctx.save();
+        if (isFF(FF_ZOOM_OPTIM)) {
+          ctx.beginPath();
+          ctx.rect(self.parent.alignmentOffset.x, self.parent.alignmentOffset.y, self.parent.stageWidth, self.parent.stageHeight);
+          ctx.clip();
+        }
         ctx.beginPath();
         if (cachedPoints.length / 2 > 3) {
           ctx.moveTo(...self.prepareCoords([lastPointX, lastPointY]));
@@ -535,7 +540,11 @@ const HtxBrushView = ({ item, setShapeRef }) => {
       if (image) {
         if (!imageData) {
           context.drawImage(image, 0, 0, item.parent.stageWidth, item.parent.stageHeight);
-          imageData = context.getImageData(0, 0, item.parent.stageWidth, item.parent.stageHeight);
+          if (isFF(FF_ZOOM_OPTIM)) {
+            imageData = context.getImageData(item.parent.alignmentOffset.x, item.parent.alignmentOffset.y, item.parent.stageWidth, item.parent.stageHeight);
+          } else {
+            imageData = context.getImageData(0, 0, item.parent.stageWidth, item.parent.stageHeight);
+          }
           const colorParts = colorToRGBAArray(shape.colorKey);
 
           for (let i = imageData.data.length / 4 - 1; i >= 0; i--) {
@@ -613,6 +622,27 @@ const HtxBrushView = ({ item, setShapeRef }) => {
   if (!item.parent) return null;
 
   const stage = item.parent?.stageRef;
+  const highlightProps = isFF(FF_ZOOM_OPTIM) ? {
+    scaleX: 1 / item.parent.zoomScale,
+    scaleY: 1 / item.parent.zoomScale,
+    x: -(item.parent.zoomingPositionX + item.parent.alignmentOffset.x) / item.parent.zoomScale,
+    y: -(item.parent.zoomingPositionY + item.parent.alignmentOffset.y) / item.parent.zoomScale,
+    width: item.containerWidth,
+    height: item.containerHeight,
+  } : {
+    scaleX: 1 / item.parent.stageScale,
+    scaleY: 1 / item.parent.stageScale,
+    x: -item.parent.zoomingPositionX / item.parent.stageScale,
+    y: -item.parent.zoomingPositionY / item.parent.stageScale,
+    width: item.parent.canvasSize.width,
+    height: item.parent.canvasSize.height,
+  };
+  const clip = isFF(FF_ZOOM_OPTIM) ? {
+    x: 0,
+    y: 0,
+    width: item.parent.stageWidth,
+    height: item.parent.stageHeight,
+  } : null;
 
   return (
     <RegionWrapper item={item}>
@@ -627,6 +657,7 @@ const HtxBrushView = ({ item, setShapeRef }) => {
         }}
         clearBeforeDraw={!item.isDrawing}
         visible={!item.hidden}
+        clip={clip}
       >
         <Group
           attrMy={item.needsUpdate}
@@ -664,6 +695,13 @@ const HtxBrushView = ({ item, setShapeRef }) => {
               return;
             }
 
+            if (!isFF(FF_ZOOM_OPTIM)) {
+              const tool = item.parent.getToolsManager().findSelectedTool();
+              const isMoveTool = tool && getType(tool).name === 'MoveTool';
+
+              if (tool && !isMoveTool) return;
+            }
+
             if (store.annotationStore.selected.relationMode) {
               stage.container().style.cursor = 'default';
             }
@@ -693,12 +731,7 @@ const HtxBrushView = ({ item, setShapeRef }) => {
             sceneFunc={highlightedRef.current.highlighted ? null : () => { }}
             hitFunc={() => { }}
             {...highlightedRef.current.highlight}
-            scaleX={1 / item.parent.stageScale}
-            scaleY={1 / item.parent.stageScale}
-            x={-item.parent.zoomingPositionX / item.parent.stageScale}
-            y={-item.parent.zoomingPositionY / item.parent.stageScale}
-            width={item.parent.stageWidth}
-            height={item.parent.stageHeight}
+            {...highlightProps}
             listening={false}
           />
         </Group>

--- a/src/regions/BrushRegion.js
+++ b/src/regions/BrushRegion.js
@@ -1,7 +1,7 @@
 import React, { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { Group, Image, Layer, Shape } from 'react-konva';
 import { observer } from 'mobx-react';
-import { getParent, getRoot, hasParent, isAlive, types } from 'mobx-state-tree';
+import { getParent, getRoot, getType, hasParent, isAlive, types } from 'mobx-state-tree';
 
 import Registry from '../core/Registry';
 import NormalizationMixin from '../mixins/Normalization';

--- a/src/regions/BrushRegion.js
+++ b/src/regions/BrushRegion.js
@@ -273,7 +273,12 @@ const Model = types
         ctx.save();
         if (isFF(FF_ZOOM_OPTIM)) {
           ctx.beginPath();
-          ctx.rect(self.parent.alignmentOffset.x, self.parent.alignmentOffset.y, self.parent.stageWidth, self.parent.stageHeight);
+          ctx.rect(
+            self.parent.alignmentOffset.x,
+            self.parent.alignmentOffset.y,
+            self.parent.stageWidth * self.parent.stageScale,
+            self.parent.stageHeight * self.parent.stageScale,
+          );
           ctx.clip();
         }
         ctx.beginPath();

--- a/src/tags/object/Image/Image.js
+++ b/src/tags/object/Image/Image.js
@@ -648,11 +648,25 @@ const Model = types.model({
     return {
       views: {
         getSkipInteractions() {
-          const manager = self.getToolsManager();
+          if (isFF(FF_ZOOM_OPTIM)) {
+            if (skipInteractions) return true;
 
-          const isPanning = manager.findSelectedTool()?.toolName === 'ZoomPanTool';
+            const relationMode = self.annotation.relationMode;
 
-          return skipInteractions || isPanning;
+            if (relationMode) return false;
+
+            const manager = self.getToolsManager();
+            const tool = manager.findSelectedTool();
+            const canInteractWithRegions = tool?.canInteractWithRegions;
+
+            return !canInteractWithRegions;
+          } else {
+            const manager = self.getToolsManager();
+
+            const isPanning = manager.findSelectedTool()?.toolName === 'ZoomPanTool';
+
+            return skipInteractions || isPanning;
+          }
         },
       },
       actions: {

--- a/src/tools/Base.js
+++ b/src/tools/Base.js
@@ -30,6 +30,7 @@ const BaseTool = types
   .volatile(() => ({
     dynamic: false,
     index: 1,
+    canInteractWithRegions: true,
   }))
   .views(self => {
     return {

--- a/src/tools/Brush.js
+++ b/src/tools/Brush.js
@@ -55,6 +55,9 @@ const _Tool = types
     smart: true,
     unselectRegionOnToolChange: isFF(FF_DEV_4081) ? false : true,
   })
+  .volatile(() => ({
+    canInteractWithRegions: false,
+  }))
   .views(self => ({
     get viewClass() {
       return () => <ToolView item={self} />;

--- a/src/tools/Erase.js
+++ b/src/tools/Erase.js
@@ -55,6 +55,7 @@ const _Tool = types
   })
   .volatile(() => ({
     index: 9999,
+    canInteractWithRegions: false,
   }))
   .views(self => ({
     get viewClass() {

--- a/src/tools/MagicWand.js
+++ b/src/tools/MagicWand.js
@@ -92,6 +92,8 @@ const _Tool = types
     unselectRegionOnToolChange: false,
   })
   .volatile(() => ({
+    canInteractWithRegions: false,
+
     currentThreshold: null,
     mask: null,
 

--- a/src/tools/Zoom.js
+++ b/src/tools/Zoom.js
@@ -69,6 +69,9 @@ const _Tool = types
     // image: types.late(() => types.safeReference(Registry.getModelByTag("image")))
     group: 'control',
   })
+  .volatile(() => ({
+    canInteractWithRegions: false,
+  }))
   .views(self => ({
     get viewClass() {
       return () => <ToolView item={self} />;

--- a/tests/functional/data/image_segmentation/tools/brush.ts
+++ b/tests/functional/data/image_segmentation/tools/brush.ts
@@ -1,0 +1,25 @@
+export const brushConfig = `
+<View>
+  <Image name="image" value="$image" crossOrigin="anonymous" />
+  <Brush name="brush" toName="image" />
+  <Labels name="label" toName="image">
+    <Label value="Label A" background="green" />
+    <Label value="Label B" background="yellow" />
+  </Labels>
+</View>
+`;
+
+export const brushCenteredConfig = `
+<View>
+  <Image name="image" value="$image" crossOrigin="anonymous" horizontalalignment="center"/>
+  <Brush name="brush" toName="image" />
+  <Labels name="label" toName="image">
+    <Label value="Label A" background="green" />
+    <Label value="Label B" background="yellow" />
+  </Labels>
+</View>
+`;
+
+export const brushImageData = {
+  image: 'https://htx-pub.s3.amazonaws.com/samples/magicwand/magic_wand_scale_1_20200902_015806_26_2235_1B_AnalyticMS_00750_00750.jpg',
+};

--- a/tests/functional/data/image_segmentation/tools/magic-wand.ts
+++ b/tests/functional/data/image_segmentation/tools/magic-wand.ts
@@ -1,0 +1,10 @@
+export const magicWandConfig = `
+<View>
+  <Image name="image" value="$image" crossOrigin="anonymous" />
+  <MagicWand name="magicwand" toName="image" />
+</View>
+`;
+
+export const magicWandImageData = {
+  image: 'https://htx-pub.s3.amazonaws.com/samples/magicwand/magic_wand_scale_1_20200902_015806_26_2235_1B_AnalyticMS_00750_00750.jpg',
+};

--- a/tests/functional/package.json
+++ b/tests/functional/package.json
@@ -20,7 +20,7 @@
     "cvg:summary": "nyc report --temp-dir=.nyc_output --reporter=text-summary --cwd=. --exclude-after-remap false"
   },
   "dependencies": {
-    "@heartexlabs/ls-test": "heartexlabs/ls-frontend-test#ebac21c25d27acb608516d24cb74547c548caa4e"
+    "@heartexlabs/ls-test": "heartexlabs/ls-frontend-test#a771403374e3d2809b7d818bd33c0cc183bc97ab"
   },
   "devDependencies": {
     "ts-loader": "^9.4.2",

--- a/tests/functional/package.json
+++ b/tests/functional/package.json
@@ -20,7 +20,7 @@
     "cvg:summary": "nyc report --temp-dir=.nyc_output --reporter=text-summary --cwd=. --exclude-after-remap false"
   },
   "dependencies": {
-    "@heartexlabs/ls-test": "heartexlabs/ls-frontend-test#eab8c0b679770f95428e0a6bb186cd0f9d249bd5"
+    "@heartexlabs/ls-test": "heartexlabs/ls-frontend-test#77cdd7758fbc4c0bcfcd5888e392cefc7cd8478d"
   },
   "devDependencies": {
     "ts-loader": "^9.4.2",

--- a/tests/functional/package.json
+++ b/tests/functional/package.json
@@ -20,7 +20,7 @@
     "cvg:summary": "nyc report --temp-dir=.nyc_output --reporter=text-summary --cwd=. --exclude-after-remap false"
   },
   "dependencies": {
-    "@heartexlabs/ls-test": "heartexlabs/ls-frontend-test#77cdd7758fbc4c0bcfcd5888e392cefc7cd8478d"
+    "@heartexlabs/ls-test": "heartexlabs/ls-frontend-test#122bb9d0a32b348af7ae7df1fdb71393efb048b1"
   },
   "devDependencies": {
     "ts-loader": "^9.4.2",

--- a/tests/functional/package.json
+++ b/tests/functional/package.json
@@ -20,7 +20,7 @@
     "cvg:summary": "nyc report --temp-dir=.nyc_output --reporter=text-summary --cwd=. --exclude-after-remap false"
   },
   "dependencies": {
-    "@heartexlabs/ls-test": "heartexlabs/ls-frontend-test#122bb9d0a32b348af7ae7df1fdb71393efb048b1"
+    "@heartexlabs/ls-test": "heartexlabs/ls-frontend-test#ebac21c25d27acb608516d24cb74547c548caa4e"
   },
   "devDependencies": {
     "ts-loader": "^9.4.2",

--- a/tests/functional/specs/image_segmentation/tools/brush.cy.ts
+++ b/tests/functional/specs/image_segmentation/tools/brush.cy.ts
@@ -1,0 +1,99 @@
+import { ImageView, Labels, LabelStudio, Sidebar } from '../../../../../../../ls-frontend-test/helpers/LSF';
+import { brushCenteredConfig, brushConfig, brushImageData } from '../../../data/image_segmentation/tools/brush';
+import { Generator } from '../../../../../../../ls-frontend-test/helpers/common/Generator';
+
+describe('Brush tool', () => {
+  it('Should be able to draw over the same brush region', () => {
+    LabelStudio.params()
+      .config(brushConfig)
+      .data(brushImageData)
+      .withResult([])
+      .init();
+
+    ImageView.waitForImage();
+
+    cy.log('Draw the region');
+    Labels.select('Label B');
+    ImageView.drawPolylineRelative([[0.1, 0.1], [0.9, 0.1], [0.1, 0.12], [0.9, 0.12], [0.1, 0.14], [0.9, 0.14]]);
+
+    cy.log('Continue drawing over the first region');
+    ImageView.drawPolylineRelative([[0.1, 0.11], [0.9, 0.11], [0.1, 0.13], [0.9, 0.13]]);
+
+    cy.log('The region, the label and the tool sholdn\'t be unselected during the drawing');
+    cy.log('Repeat once again');
+    ImageView.drawPolylineRelative([[0.3, 0.12], [0.7, 0.12]]);
+
+    cy.log('As well as we drawing the same region, there should be only one region at the sidebar');
+    Sidebar.hasRegions(1);
+  });
+
+  it('Should be able to erase continuously', () => {
+    LabelStudio.params()
+      .config(brushConfig)
+      .data(brushImageData)
+      .withResult([])
+      .init();
+
+    ImageView.waitForImage();
+
+    cy.log('Draw the region');
+    Labels.select('Label B');
+    ImageView.drawPolylineRelative([[0.1, 0.1], [0.9, 0.1], [0.1, 0.12], [0.9, 0.12], [0.1, 0.14], [0.9, 0.14]]);
+
+    ImageView.selectEraserToolByButton();
+    ImageView.drawPolylineRelative([[0.3, 0.12], [0.7, 0.12]]);
+
+    Sidebar.hasSelectedRegion(0);
+  });
+
+  it('Should draw only within the boundaries of the canvas', () => {
+    Generator.generateImageUrl({ width: 50, height: 100 })
+      .then((imageData) => {
+        LabelStudio.params()
+          .config(brushConfig)
+          .data({ image: imageData })
+          .withResult([])
+          .init();
+
+        ImageView.waitForImage();
+
+        Labels.select('Label A');
+        ImageView.drawPolylineRelative([[0.1, 0.3], [2, 0.7]], {
+          beforeMouseup() {
+            ImageView.pixelRelativeShouldBe(0.1, 0.3, '#64b164');
+            ImageView.pixelRelativeShouldBe(2, 0.7, '#fafafa');
+          },
+        });
+
+        ImageView.pixelRelativeShouldBe(0.1, 0.3, '#64b164');
+        ImageView.pixelRelativeShouldBe(2, 0.7, '#fafafa');
+      });
+  });
+
+  it('Should draw only within the boundaries of the canvas even with centered image', () => {
+    Generator.generateImageUrl({ width: 50, height: 100 })
+      .then((imageData) => {
+        LabelStudio.params()
+          .config(brushCenteredConfig)
+          .data({ image: imageData })
+          .withResult([])
+          .init();
+
+        ImageView.waitForImage();
+
+        Labels.select('Label A');
+        ImageView.drawingArea.trigger('mousemove', 353, 282);
+        ImageView.drawPolylineRelative([[0.5, 0.3], [2, 0.7]], {
+          beforeMouseup() {
+            ImageView.pixelRelativeShouldBe(0.5, 0.3, '#fafafa');
+            ImageView.pixelRelativeShouldBe(1, 0.433, '#64b164');
+            ImageView.pixelRelativeShouldBe(2, 0.7, '#fafafa');
+          },
+        });
+
+        ImageView.pixelRelativeShouldBe(0.5, 0.3, '#fafafa');
+        ImageView.pixelRelativeShouldBe(1, 0.433, '#64b164');
+        ImageView.pixelRelativeShouldBe(2, 0.7, '#fafafa');
+      });
+  });
+});

--- a/tests/functional/specs/image_segmentation/tools/brush.cy.ts
+++ b/tests/functional/specs/image_segmentation/tools/brush.cy.ts
@@ -58,15 +58,15 @@ describe('Brush tool', () => {
         ImageView.waitForImage();
 
         Labels.select('Label A');
-        ImageView.drawPolylineRelative([[0.1, 0.3], [2, 0.7]], {
+        ImageView.drawPolylineRelative([[0.1, 0.3], [2, 0.1]], {
           beforeMouseup() {
             ImageView.pixelRelativeShouldBe(0.1, 0.3, '#64b164');
-            ImageView.pixelRelativeShouldBe(2, 0.7, '#fafafa');
+            ImageView.pixelRelativeShouldBe(2, 0.1, '#fafafa');
           },
         });
 
         ImageView.pixelRelativeShouldBe(0.1, 0.3, '#64b164');
-        ImageView.pixelRelativeShouldBe(2, 0.7, '#fafafa');
+        ImageView.pixelRelativeShouldBe(2, 0.1, '#fafafa');
       });
   });
 
@@ -82,17 +82,17 @@ describe('Brush tool', () => {
         ImageView.waitForImage();
 
         Labels.select('Label A');
-        ImageView.drawPolylineRelative([[0.5, 0.3], [2, 0.7]], {
+        ImageView.drawPolylineRelative([[0.5, 0.3], [2, 0.1]], {
           beforeMouseup() {
             ImageView.pixelRelativeShouldBe(0.5, 0.3, '#fafafa');
-            ImageView.pixelRelativeShouldBe(1, 0.433, '#64b164');
-            ImageView.pixelRelativeShouldBe(2, 0.7, '#fafafa');
+            ImageView.pixelRelativeShouldBe(1, 0.234, '#64b164');
+            ImageView.pixelRelativeShouldBe(2, 0.1, '#fafafa');
           },
         });
 
         ImageView.pixelRelativeShouldBe(0.5, 0.3, '#fafafa');
-        ImageView.pixelRelativeShouldBe(1, 0.433, '#64b164');
-        ImageView.pixelRelativeShouldBe(2, 0.7, '#fafafa');
+        ImageView.pixelRelativeShouldBe(1, 0.234, '#64b164');
+        ImageView.pixelRelativeShouldBe(2, 0.1, '#fafafa');
       });
   });
 });

--- a/tests/functional/specs/image_segmentation/tools/brush.cy.ts
+++ b/tests/functional/specs/image_segmentation/tools/brush.cy.ts
@@ -82,7 +82,6 @@ describe('Brush tool', () => {
         ImageView.waitForImage();
 
         Labels.select('Label A');
-        ImageView.drawingArea.trigger('mousemove', 353, 282);
         ImageView.drawPolylineRelative([[0.5, 0.3], [2, 0.7]], {
           beforeMouseup() {
             ImageView.pixelRelativeShouldBe(0.5, 0.3, '#fafafa');

--- a/tests/functional/specs/image_segmentation/tools/brush.cy.ts
+++ b/tests/functional/specs/image_segmentation/tools/brush.cy.ts
@@ -1,6 +1,6 @@
-import { ImageView, Labels, LabelStudio, Sidebar } from '../../../../../../../ls-frontend-test/helpers/LSF';
+import { ImageView, Labels, LabelStudio, Sidebar } from '@heartexlabs/ls-test/helpers/LSF';
 import { brushCenteredConfig, brushConfig, brushImageData } from '../../../data/image_segmentation/tools/brush';
-import { Generator } from '../../../../../../../ls-frontend-test/helpers/common/Generator';
+import { Generator } from '@heartexlabs/ls-test/helpers/common/Generator';
 
 describe('Brush tool', () => {
   it('Should be able to draw over the same brush region', () => {

--- a/tests/functional/specs/image_segmentation/tools/magic-wand.cy.ts
+++ b/tests/functional/specs/image_segmentation/tools/magic-wand.cy.ts
@@ -1,0 +1,43 @@
+import { ImageView, LabelStudio, Sidebar } from '@heartexlabs/ls-test/helpers/LSF';
+import { magicWandConfig, magicWandImageData } from '../../../data/image_segmentation/tools/magic-wand';
+import { FF_DEV_4081 } from '../../../../../src/utils/feature-flags';
+
+describe('Magic Wand tool', () => {
+  beforeEach(() => {
+    LabelStudio.addFeatureFlagsOnPageLoad({
+      [FF_DEV_4081]: true,
+    });
+  });
+
+  it('Should be able to extend the same region', () => {
+    LabelStudio.params()
+      .config(magicWandConfig)
+      .data(magicWandImageData)
+      .withResult([])
+      .init();
+
+    ImageView.waitForImage();
+
+    ImageView.clickAtRelative(.1, .1);
+    ImageView.clickAtRelative(.9, .9);
+    ImageView.clickAtRelative(.5, .5);
+
+    Sidebar.hasRegions(1);
+  });
+
+  it('Should not switch to another layer while clicking the same region', () => {
+    LabelStudio.params()
+      .config(magicWandConfig)
+      .data(magicWandImageData)
+      .withResult([])
+      .init();
+
+    ImageView.waitForImage();
+
+    ImageView.clickAtRelative(.5, .5);
+    ImageView.clickAtRelative(.5, .5);
+    ImageView.clickAtRelative(.5, .5);
+
+    Sidebar.hasRegions(1);
+  });
+});

--- a/tests/functional/yarn.lock
+++ b/tests/functional/yarn.lock
@@ -264,9 +264,9 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
 
-"@heartexlabs/ls-test@heartexlabs/ls-frontend-test#122bb9d0a32b348af7ae7df1fdb71393efb048b1":
+"@heartexlabs/ls-test@heartexlabs/ls-frontend-test#a771403374e3d2809b7d818bd33c0cc183bc97ab":
   version "1.0.8"
-  resolved "https://codeload.github.com/heartexlabs/ls-frontend-test/tar.gz/122bb9d0a32b348af7ae7df1fdb71393efb048b1"
+  resolved "https://codeload.github.com/heartexlabs/ls-frontend-test/tar.gz/a771403374e3d2809b7d818bd33c0cc183bc97ab"
   dependencies:
     "@cypress/code-coverage" "^3.10.0"
     "@cypress/webpack-preprocessor" "^5.17.0"

--- a/tests/functional/yarn.lock
+++ b/tests/functional/yarn.lock
@@ -264,9 +264,9 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
 
-"@heartexlabs/ls-test@git+ssh://git@github.com/heartexlabs/ls-frontend-test#eab8c0b679770f95428e0a6bb186cd0f9d249bd5":
+"@heartexlabs/ls-test@heartexlabs/ls-frontend-test#77cdd7758fbc4c0bcfcd5888e392cefc7cd8478d":
   version "1.0.8"
-  resolved "git+ssh://git@github.com/heartexlabs/ls-frontend-test#eab8c0b679770f95428e0a6bb186cd0f9d249bd5"
+  resolved "https://codeload.github.com/heartexlabs/ls-frontend-test/tar.gz/77cdd7758fbc4c0bcfcd5888e392cefc7cd8478d"
   dependencies:
     "@cypress/code-coverage" "^3.10.0"
     "@cypress/webpack-preprocessor" "^5.17.0"
@@ -290,7 +290,6 @@
 
 "@heartexlabs/ls-test@heartexlabs/ls-frontend-test#eab8c0b679770f95428e0a6bb186cd0f9d249bd5":
   version "1.0.8"
-  uid eab8c0b679770f95428e0a6bb186cd0f9d249bd5
   resolved "https://codeload.github.com/heartexlabs/ls-frontend-test/tar.gz/eab8c0b679770f95428e0a6bb186cd0f9d249bd5"
   dependencies:
     "@cypress/code-coverage" "^3.10.0"

--- a/tests/functional/yarn.lock
+++ b/tests/functional/yarn.lock
@@ -264,9 +264,9 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
 
-"@heartexlabs/ls-test@heartexlabs/ls-frontend-test#77cdd7758fbc4c0bcfcd5888e392cefc7cd8478d":
+"@heartexlabs/ls-test@heartexlabs/ls-frontend-test#122bb9d0a32b348af7ae7df1fdb71393efb048b1":
   version "1.0.8"
-  resolved "https://codeload.github.com/heartexlabs/ls-frontend-test/tar.gz/77cdd7758fbc4c0bcfcd5888e392cefc7cd8478d"
+  resolved "https://codeload.github.com/heartexlabs/ls-frontend-test/tar.gz/122bb9d0a32b348af7ae7df1fdb71393efb048b1"
   dependencies:
     "@cypress/code-coverage" "^3.10.0"
     "@cypress/webpack-preprocessor" "^5.17.0"
@@ -288,9 +288,9 @@
     webpack-cli "^5.0.1"
     yargs "^17.7.1"
 
-"@heartexlabs/ls-test@heartexlabs/ls-frontend-test#eab8c0b679770f95428e0a6bb186cd0f9d249bd5":
+"@heartexlabs/ls-test@heartexlabs/ls-frontend-test#77cdd7758fbc4c0bcfcd5888e392cefc7cd8478d":
   version "1.0.8"
-  resolved "https://codeload.github.com/heartexlabs/ls-frontend-test/tar.gz/eab8c0b679770f95428e0a6bb186cd0f9d249bd5"
+  resolved "https://codeload.github.com/heartexlabs/ls-frontend-test/tar.gz/77cdd7758fbc4c0bcfcd5888e392cefc7cd8478d"
   dependencies:
     "@cypress/code-coverage" "^3.10.0"
     "@cypress/webpack-preprocessor" "^5.17.0"

--- a/tests/functional/yarn.lock
+++ b/tests/functional/yarn.lock
@@ -288,9 +288,9 @@
     webpack-cli "^5.0.1"
     yargs "^17.7.1"
 
-"@heartexlabs/ls-test@heartexlabs/ls-frontend-test#77cdd7758fbc4c0bcfcd5888e392cefc7cd8478d":
+"@heartexlabs/ls-test@heartexlabs/ls-frontend-test#ebac21c25d27acb608516d24cb74547c548caa4e":
   version "1.0.8"
-  resolved "https://codeload.github.com/heartexlabs/ls-frontend-test/tar.gz/77cdd7758fbc4c0bcfcd5888e392cefc7cd8478d"
+  resolved "https://codeload.github.com/heartexlabs/ls-frontend-test/tar.gz/ebac21c25d27acb608516d24cb74547c548caa4e"
   dependencies:
     "@cypress/code-coverage" "^3.10.0"
     "@cypress/webpack-preprocessor" "^5.17.0"


### PR DESCRIPTION
### PR fulfills these requirements
- [x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [x] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [x] Frontend



### Describe the reason for change
Fixes after https://github.com/HumanSignal/label-studio-frontend/pull/1565 for LEAP-32

#### What does this fix?
- an issue with wrong position of brush stroke highlighted on hover. 
- an issue with clipping brush strokes by image boundaries.
- an issue with drawing and erasing over existing brush regions.

#### What libraries were added/updated?
`@heartexlabs/ls-test`

#### Does this change affect performance?
Nope

#### Does this change affect security?
Nope

#### What alternative approaches were there?
N/A

#### What feature flags were used to cover this change?
`fflag_fix_front_leap_32_zoom_perf_190923_short`


### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [x] No
- [ ] Not sure (briefly explain the situation below)

### What level of testing was included in the change?
_(check all that apply)_
- [ ] e2e
- [x] integration
- [ ] unit

### Which logical domain(s) does this change affect?
`Brush`, `Magic wand`, `Image Segmentation`