### PR TITLE
fix: LEAP-377: Polygon points can be moved correctly

### DIFF
--- a/src/regions/PolygonRegion.js
+++ b/src/regions/PolygonRegion.js
@@ -471,9 +471,7 @@ const Poly = memo(observer(({ item, colors, dragProps, draggable }) => {
  */
 function Edge({ name, item, idx, p1, p2, closed, regionStyles }) {
   const insertIdx = idx + 1; // idx1 + 1 or idx2
-  const flattenedPoints = useMemo(() => {
-    return getFlattenedPoints([p1, p2]);
-  }, [p1, p2]);
+  const flattenedPoints = [p1.canvasX, p1.canvasY, p2.canvasX, p2.canvasY];
 
   const lineProps = closed ? {
     stroke: 'transparent',

--- a/src/regions/PolygonRegion.js
+++ b/src/regions/PolygonRegion.js
@@ -469,7 +469,7 @@ const Poly = memo(observer(({ item, colors, dragProps, draggable }) => {
 /**
  * Line between 2 points
  */
-function Edge({ name, item, idx, p1, p2, closed, regionStyles }) {
+const Edge = observer(({ name, item, idx, p1, p2, closed, regionStyles }) => {
   const insertIdx = idx + 1; // idx1 + 1 or idx2
   const flattenedPoints = [p1.canvasX, p1.canvasY, p2.canvasX, p2.canvasY];
 
@@ -507,7 +507,7 @@ function Edge({ name, item, idx, p1, p2, closed, regionStyles }) {
       />
     </Group>
   );
-}
+});
 
 const Edges = memo(observer(({ item, regionStyles }) => {
   const { points,closed } = item;

--- a/src/tags/control/Taxonomy/Taxonomy.js
+++ b/src/tags/control/Taxonomy/Taxonomy.js
@@ -90,7 +90,7 @@ import { errorBuilder } from '../../../core/DataValidator/ConfigValidator';
  * @param {string} [placeholder=]         - What to display as prompt on the input
  * @param {boolean} [perRegion]           - Use this tag to classify specific regions instead of the whole object
  * @param {boolean} [perItem]             - Use this tag to classify specific items inside the object instead of the whole object[^FF_LSDV_4583]
- * @param {boolean} [legacy]              - Use this tag to enable the legacy version of the Taxonomy tag. When true, the `apiUrl` parameter is not useable[^FF_TAXONOMY_ASYNC]
+ * @param {boolean} [legacy]              - Use this tag to enable the legacy version of the Taxonomy tag. When true, the `apiUrl` parameter is not usable[^FF_TAXONOMY_ASYNC]
  */
 const TagAttrs = types.model({
   toname: types.maybeNull(types.string),


### PR DESCRIPTION
While drawing a polygon user can move already added points. However those points did not move lines connected to them, creating visual glitch. Actual point coords were correct.

The problem is that lines have memoization for their coords, based on point objects.
But when any of two points was moved this was not changed the object and was not triggering re-render of the line.

### PR fulfills these requirements
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)

### This change affects (describe how if yes)
- [ ] Performance
- [ ] Security
- [x] UX

### Does this PR introduce a breaking change?
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [x] No
- [ ] Not sure (briefly explain the situation below)

### What level of testing was included in the change?
- [ ] e2e (codecept)
- [ ] integration (cypress)
- [ ] unit (jest)
