### PR TITLE
fix: LEAP-89: Fix rendering of relation arrow in MIG case

### DIFF
--- a/src/components/RelationsOverlay/NodesConnector.js
+++ b/src/components/RelationsOverlay/NodesConnector.js
@@ -5,7 +5,7 @@ import { RelationShape } from './RelationShape';
 import { createPropertyWatcher, DOMWatcher } from './watchers';
 
 const parentImagePropsWatch = {
-  parent: ['zoomScale', 'zoomingPositionX', 'zoomingPositionY', 'rotation'],
+  parent: ['zoomScale', 'zoomingPositionX', 'zoomingPositionY', 'rotation', 'currentImage'],
 };
 
 const obtainWatcher = node => {


### PR DESCRIPTION
### PR fulfills these requirements
- [x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)

#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [x] Frontend

### Describe the reason for change
In the case of Image Segmentation with Image tag being in gallery mode a relation arrow may not follow the regions on switching between images.


#### What does this fix?
It adds an directive for relation to observe current image index to initiate rendering of an arrow on switching between images.

#### What libraries were added/updated?
N/A

#### Does this change affect performance?
Nope

#### Does this change affect security?
Nope

#### What alternative approaches were there?
N/A

#### What feature flags were used to cover this change?
N/A

### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [x] No
- [ ] Not sure (briefly explain the situation below)

### What level of testing was included in the change?
_(check all that apply)_
- [ ] e2e
- [ ] integration
- [ ] unit

### Which logical domain(s) does this change affect?
`Image Segmentation`, `Image`, `Relations`, `Gallery`