### PR TITLE
feat: LEAP-355: Make relations work with TimeTraveler

### DIFF
--- a/src/components/RelationsOverlay/RelationsOverlay.js
+++ b/src/components/RelationsOverlay/RelationsOverlay.js
@@ -171,6 +171,7 @@ const RelationItemObserver = observer(({ relation, startNode, endNode, visible, 
       endNode={endNode}
       direction={relation.direction}
       visible={visibility}
+      labels={relation.selectedValues}
       {...rest}
     />
   ) : null;
@@ -229,7 +230,6 @@ class RelationsOverlay extends PureComponent {
           rootRef={this.rootNode}
           startNode={relation.node1}
           endNode={relation.node2}
-          labels={relation.relations?.selectedValues()}
           dimm={hasHighlight && !highlighted}
           highlight={highlighted}
           visible={highlighted || visible}

--- a/src/components/SidePanels/DetailsPanel/Relations.styl
+++ b/src/components/SidePanels/DetailsPanel/Relations.styl
@@ -31,6 +31,7 @@
 
   &__icon
     width 24px
+    min-height 24px
     display flex
     flex none
     position relative

--- a/src/components/SidePanels/DetailsPanel/Relations.tsx
+++ b/src/components/SidePanels/DetailsPanel/Relations.tsx
@@ -128,9 +128,8 @@ const RelationItem: FC<{relation: any}> = observer(({ relation }) => {
 });
 
 const RelationMeta: FC<any> = ({ relation }) => {
-  const { relations } = relation;
-  const { children, choice } = relations;
-  const selected = relations.getSelected().map((v: any) => v.value);
+  const { selectedValues, control } = relation;
+  const { children, choice } = control;
 
   const selectionMode = useMemo(() => {
     return choice === 'multiple' ? 'multiple' : undefined;
@@ -139,8 +138,7 @@ const RelationMeta: FC<any> = ({ relation }) => {
   const onChange = useCallback((val: any) => {
     const values: any[] = wrapArray(val);
 
-    relations.unselectAll();
-    values.forEach(v => relations.findRelation(v).setSelected(true));
+    relation.setRelations(values);
   }, []);
 
   return (
@@ -149,7 +147,7 @@ const RelationMeta: FC<any> = ({ relation }) => {
         mode={selectionMode}
         style={{ width: '100%' }}
         placeholder="Select labels"
-        defaultValue={selected}
+        defaultValue={selectedValues}
         onChange={onChange}
       >
         {children.map((c: any) => (

--- a/src/components/SidePanels/DetailsPanel/Relations.tsx
+++ b/src/components/SidePanels/DetailsPanel/Relations.tsx
@@ -56,9 +56,9 @@ const RelationItem: FC<{relation: any}> = observer(({ relation }) => {
     const { direction } = relation;
 
     switch (direction) {
-      case 'left': return <IconRelationLeft/>;
-      case 'right': return <IconRelationRight/>;
-      case 'bi': return <IconRelationBi/>;
+      case 'left': return <IconRelationLeft data-direction={relation.direction}/>;
+      case 'right': return <IconRelationRight data-direction={relation.direction}/>;
+      case 'bi': return <IconRelationBi data-direction={relation.direction}/>;
       default: return null;
     }
   }, [relation.direction]);
@@ -92,6 +92,7 @@ const RelationItem: FC<{relation: any}> = observer(({ relation }) => {
             {(hovered || relation.showMeta) && relation.hasRelations && (
               <Button
                 primary={relation.showMeta}
+                aria-label={`${relation.showMeta ? 'Hide' : 'Show'} Relation Labels`}
                 type={relation.showMeta ? undefined : 'text'}
                 onClick={relation.toggleMeta}
                 style={{ padding: 0 }}
@@ -102,14 +103,14 @@ const RelationItem: FC<{relation: any}> = observer(({ relation }) => {
           </Elem>
           <Elem name="action">
             {(hovered || !relation.visible) && (
-              <Button type="text" onClick={relation.toggleVisibility}>
+              <Button type="text" onClick={relation.toggleVisibility} aria-label={`${relation.visible ? 'Hide' : 'Show'} Relation`}>
                 {relation.visible ? <IconEyeOpened/> : <IconEyeClosed />}
               </Button>
             )}
           </Elem>
           <Elem name="action">
             {hovered && (
-              <Button type="text" danger onClick={() => {
+              <Button type="text" danger aria-label="Delete Relation" onClick={() => {
                 relation.node1.setHighlight(false);
                 relation.node2.setHighlight(false);
                 relation.parent.deleteRelation(relation);

--- a/src/components/SidePanels/DetailsPanel/Relations.tsx
+++ b/src/components/SidePanels/DetailsPanel/Relations.tsx
@@ -148,7 +148,7 @@ const RelationMeta: FC<any> = ({ relation }) => {
         mode={selectionMode}
         style={{ width: '100%' }}
         placeholder="Select labels"
-        defaultValue={selectedValues}
+        value={selectedValues}
         onChange={onChange}
       >
         {children.map((c: any) => (

--- a/src/components/SidePanels/DetailsPanel/Relations.tsx
+++ b/src/components/SidePanels/DetailsPanel/Relations.tsx
@@ -128,7 +128,7 @@ const RelationItem: FC<{relation: any}> = observer(({ relation }) => {
   );
 });
 
-const RelationMeta: FC<any> = ({ relation }) => {
+const RelationMeta: FC<any> = observer(({ relation }) => {
   const { selectedValues, control } = relation;
   const { children, choice } = control;
 
@@ -140,7 +140,7 @@ const RelationMeta: FC<any> = ({ relation }) => {
     const values: any[] = wrapArray(val);
 
     relation.setRelations(values);
-  }, []);
+  }, [relation]);
 
   return (
     <Block name="relation-meta">
@@ -159,6 +159,6 @@ const RelationMeta: FC<any> = ({ relation }) => {
       </Select>
     </Block>
   );
-};
+});
 
 export const Relations = observer(RealtionsComponent);

--- a/src/stores/RelationStore.js
+++ b/src/stores/RelationStore.js
@@ -178,7 +178,7 @@ const RelationStore = types
       self._relations = [];
     },
 
-    serializeAnnotation() {
+    serialize() {
       return self.relations.map(r => {
         const s = {
           from_id: r.node1.cleanId,

--- a/src/stores/RelationStore.js
+++ b/src/stores/RelationStore.js
@@ -1,7 +1,6 @@
 import { destroy, getParentOfType, getRoot, isAlive, types } from 'mobx-state-tree';
 
 import { guidGenerator } from '../core/Helpers';
-import { RelationsModel } from '../tags/control/Relations';
 import Tree, { TRAVERSE_SKIP } from '../core/Tree';
 import Area from '../regions/Area';
 import { isDefined } from '../utils/utilities';
@@ -20,11 +19,11 @@ const Relation = types
 
     // labels
     labels: types.maybeNull(types.array(types.string)),
-
-    showMeta: types.optional(types.boolean, false),
-
-    visible: true,
   })
+  .volatile(() => ({
+    showMeta: false,
+    visible: true,
+  }))
   .views(self => ({
     get parent() {
       return getParentOfType(self, RelationStore);
@@ -108,11 +107,16 @@ const Relation = types
 const RelationStore = types
   .model('RelationStore', {
     relations: types.array(Relation),
-    showConnections: types.optional(types.boolean, true),
-    highlighted: types.maybeNull(types.safeReference(Relation)),
-    control: types.maybeNull(types.safeReference(RelationsModel)),
   })
+  .volatile(() => ({
+    showConnections: true,
+    _highlighted: null,
+    control: null,
+  }))
   .views(self => ({
+    get highlighted() {
+      return self.relations.find(r => r.id === self._highlighted);
+    },
     get size() {
       return self.relations.length;
     },
@@ -214,11 +218,11 @@ const RelationStore = types
     },
 
     setHighlight(relation) {
-      self.highlighted = relation;
+      self._highlighted = relation.id;
     },
 
     removeHighlight() {
-      self.highlighted = null;
+      self._highlighted = null;
     },
   }));
 

--- a/src/stores/RelationStore.js
+++ b/src/stores/RelationStore.js
@@ -2,7 +2,7 @@ import { destroy, getParentOfType, getRoot, isAlive, types } from 'mobx-state-tr
 
 import { guidGenerator } from '../core/Helpers';
 import { RelationsModel } from '../tags/control/Relations';
-import { TRAVERSE_SKIP } from '../core/Tree';
+import Tree, { TRAVERSE_SKIP } from '../core/Tree';
 import Area from '../regions/Area';
 import { isDefined } from '../utils/utilities';
 
@@ -122,13 +122,12 @@ const RelationStore = types
   }))
   .actions(self => ({
     afterAttach() {
-      const root = getRoot(self);
-      const c = root.annotationStore.selected;
+      const appStore = getRoot(self);
 
       // find <Relations> tag in the tree
       let relationsTag = null;
 
-      c.traverseTree(function(node) {
+      Tree.traverseTree(appStore.annotationStore.root, function(node) {
         if (node.type === 'relations') {
           relationsTag = node;
           return TRAVERSE_SKIP;

--- a/src/stores/RelationStore.js
+++ b/src/stores/RelationStore.js
@@ -1,4 +1,4 @@
-import { destroy, getParent, getParentOfType, isAlive, types } from 'mobx-state-tree';
+import { destroy, getParentOfType, getRoot, isAlive, types } from 'mobx-state-tree';
 
 import { guidGenerator } from '../core/Helpers';
 import { RelationsModel } from '../tags/control/Relations';
@@ -122,7 +122,8 @@ const RelationStore = types
   }))
   .actions(self => ({
     afterAttach() {
-      const c = getParent(self);
+      const root = getRoot(self);
+      const c = root.annotationStore.selected;
 
       // find <Relations> tag in the tree
       let relationsTag = null;

--- a/src/stores/RelationStore.js
+++ b/src/stores/RelationStore.js
@@ -1,6 +1,6 @@
-import { destroy, getParentOfType, getRoot, isAlive, isValidReference, types } from 'mobx-state-tree';
+import { destroy, getParent, getParentOfType, isAlive, types } from 'mobx-state-tree';
 
-import { cloneNode, guidGenerator } from '../core/Helpers';
+import { guidGenerator } from '../core/Helpers';
 import { RelationsModel } from '../tags/control/Relations';
 import { TRAVERSE_SKIP } from '../core/Tree';
 import Area from '../regions/Area';

--- a/src/tags/control/Relation.js
+++ b/src/tags/control/Relation.js
@@ -35,13 +35,9 @@ const TagAttrs = types.model({
 const Model = types
   .model({
     id: types.optional(types.identifier, guidGenerator),
-    selected: types.optional(types.boolean, false),
     type: 'relation',
   })
   .actions(self => ({
-    setSelected(value) {
-      self.selected = value;
-    },
   }));
 
 const RelationModel = types.compose('RelationModel', TagAttrs, Model);

--- a/src/tags/control/Relation.js
+++ b/src/tags/control/Relation.js
@@ -37,7 +37,7 @@ const Model = types
     id: types.optional(types.identifier, guidGenerator),
     type: 'relation',
   })
-  .actions(self => ({
+  .actions(() => ({
   }));
 
 const RelationModel = types.compose('RelationModel', TagAttrs, Model);

--- a/src/tags/control/Relations.js
+++ b/src/tags/control/Relations.js
@@ -3,7 +3,6 @@ import { types } from 'mobx-state-tree';
 import Registry from '../../core/Registry';
 import Types from '../../core/Types';
 import { guidGenerator } from '../../core/Helpers';
-import { AnnotationMixin } from '../../mixins/AnnotationMixin';
 
 /**
  * The `Relations` tag is used to create label relations between regions. Use to provide many values to apply to the relationship between two labeled regions.
@@ -52,7 +51,7 @@ const ModelAttrs = types
       return self.children.find(c => c.value === value);
     },
   }))
-  .actions(self => ({
+  .actions(() => ({
   }));
 
 const RelationsModel = types.compose('RelationsModel', ModelAttrs, TagAttrs);

--- a/src/tags/control/Relations.js
+++ b/src/tags/control/Relations.js
@@ -3,6 +3,7 @@ import { types } from 'mobx-state-tree';
 import Registry from '../../core/Registry';
 import Types from '../../core/Types';
 import { guidGenerator } from '../../core/Helpers';
+import { AnnotationMixin } from '../../mixins/AnnotationMixin';
 
 /**
  * The `Relations` tag is used to create label relations between regions. Use to provide many values to apply to the relationship between two labeled regions.
@@ -38,27 +39,20 @@ const TagAttrs = types.model({
  */
 const ModelAttrs = types
   .model({
+    id: types.optional(types.identifier, guidGenerator),
     pid: types.optional(types.string, guidGenerator),
     type: 'relations',
-    children: Types.unionArray(['relations', 'relation']),
+    children: Types.unionArray(['relation']),
   })
   .views(self => ({
-    getSelected() {
-      return self.children.filter(c => c.selected === true);
+    get values() {
+      return self.children.map(c => c.value);
     },
-
-    selectedValues() {
-      return self.getSelected().map(c => c.value);
-    },
-
     findRelation(value) {
       return self.children.find(c => c.value === value);
     },
   }))
   .actions(self => ({
-    unselectAll() {
-      self.children.map(c => c.setSelected(false));
-    },
   }));
 
 const RelationsModel = types.compose('RelationsModel', ModelAttrs, TagAttrs);

--- a/tests/functional/data/relations/basic.ts
+++ b/tests/functional/data/relations/basic.ts
@@ -1,0 +1,81 @@
+export const simpleImageConfig = `<View>
+  <Image name="image" value="$image"/>
+  <RectangleLabels name="label" toName="image">
+    <Label value="Region" background="yellow" />
+  </RectangleLabels>
+</View>`;
+
+export const imageConfigWithRelations = `<View>
+  <Image name="image" value="$image"/>
+  <RectangleLabels name="label" toName="image">
+    <Label value="Region" background="yellow" />
+  </RectangleLabels>
+  <Relations>
+    <Relation value="Blue label" background="blue"/>
+    <Relation value="Red label" background="red"/>
+    <Relation value="Green label" background="green"/>
+  </Relations>
+</View>`;
+
+export const simpleImageData = {
+  image: 'https://htx-misc.s3.amazonaws.com/opensource/label-studio/examples/images/nick-owuor-astro-nic-visuals-wDifg5xc9Z4-unsplash.jpg',
+};
+
+function rectangleResult(id, x, y, width, height, labels = ['Region']) {
+  return {
+    'id': id.toString(),
+    'from_name': 'label',
+    'to_name': 'image',
+    'original_width': 2242,
+    'original_height': 2802,
+    'image_rotation': 0,
+    'type': 'rectanglelabels',
+    'value': {
+      x,
+      y,
+      width,
+      height,
+      'rotation': 0,
+      'rectanglelabels': ['Region'],
+    },
+  };
+}
+
+function relationResult(fromId, toId, direction = 'right', labels = []) {
+  return {
+    'from_id': fromId,
+    'to_id': toId,
+    'type': 'relation',
+    direction,
+    labels,
+  };
+}
+
+export const simpleImageResult = [
+  rectangleResult('Id_1', 20, 20, 20, 20),
+  rectangleResult('Id_2', 50, 50, 30, 30),
+];
+
+export const simpleImageResultWithRelation = [
+  rectangleResult('Id_1', 20, 20, 20, 20),
+  rectangleResult('Id_2', 50, 50, 30, 30),
+  relationResult('Id_1', 'Id_2'),
+];
+
+export const simpleImageResultWithRelations = [
+  rectangleResult('Id_1', 5, 5, 5, 5),
+  rectangleResult('Id_2', 15, 5, 5, 5),
+  rectangleResult('Id_3', 10, 15, 5, 5),
+  rectangleResult('Id_4', 20, 15, 5, 5),
+  rectangleResult('Id_5', 15, 25, 5, 5),
+  rectangleResult('Id_6', 25, 25, 5, 5),
+  relationResult('Id_1', 'Id_2'),
+  relationResult('Id_3', 'Id_4', 'left'),
+  relationResult('Id_5', 'Id_6', 'bi'),
+];
+
+export const simpleImageResultWithRelationsAndLabels = [
+  rectangleResult('Id_1', 5, 5, 5, 5),
+  rectangleResult('Id_2', 25, 25, 5, 5),
+  relationResult('Id_1', 'Id_2', 'right', ['Blue label', 'Red label']),
+];

--- a/tests/functional/data/relations/basic.ts
+++ b/tests/functional/data/relations/basic.ts
@@ -79,3 +79,9 @@ export const simpleImageResultWithRelationsAndLabels = [
   rectangleResult('Id_2', 25, 25, 5, 5),
   relationResult('Id_1', 'Id_2', 'right', ['Blue label', 'Red label']),
 ];
+
+export const simpleImageResultWithRelationsAndLabelsAlt = [
+  rectangleResult('Id_1', 5, 5, 5, 5),
+  rectangleResult('Id_2', 25, 25, 5, 5),
+  relationResult('Id_1', 'Id_2', 'right', ['Green label']),
+];

--- a/tests/functional/package.json
+++ b/tests/functional/package.json
@@ -20,7 +20,7 @@
     "cvg:summary": "nyc report --temp-dir=.nyc_output --reporter=text-summary --cwd=. --exclude-after-remap false"
   },
   "dependencies": {
-    "@heartexlabs/ls-test": "heartexlabs/ls-frontend-test#82ed8ce353a84a087f285a107f86768bbcb3e133"
+    "@heartexlabs/ls-test": "heartexlabs/ls-frontend-test#70666737e54c15edb505a0986d2ca3c4f15c57b3"
   },
   "devDependencies": {
     "ts-loader": "^9.4.2",

--- a/tests/functional/package.json
+++ b/tests/functional/package.json
@@ -20,7 +20,7 @@
     "cvg:summary": "nyc report --temp-dir=.nyc_output --reporter=text-summary --cwd=. --exclude-after-remap false"
   },
   "dependencies": {
-    "@heartexlabs/ls-test": "heartexlabs/ls-frontend-test#70666737e54c15edb505a0986d2ca3c4f15c57b3"
+    "@heartexlabs/ls-test": "heartexlabs/ls-frontend-test#e760e117af39c187065ec8c704ce174e5d001eff"
   },
   "devDependencies": {
     "ts-loader": "^9.4.2",

--- a/tests/functional/package.json
+++ b/tests/functional/package.json
@@ -20,7 +20,7 @@
     "cvg:summary": "nyc report --temp-dir=.nyc_output --reporter=text-summary --cwd=. --exclude-after-remap false"
   },
   "dependencies": {
-    "@heartexlabs/ls-test": "heartexlabs/ls-frontend-test#2a8ade2c44636ba1b263222b6338928e5b7ce919"
+    "@heartexlabs/ls-test": "heartexlabs/ls-frontend-test#82ed8ce353a84a087f285a107f86768bbcb3e133"
   },
   "devDependencies": {
     "ts-loader": "^9.4.2",

--- a/tests/functional/package.json
+++ b/tests/functional/package.json
@@ -20,7 +20,7 @@
     "cvg:summary": "nyc report --temp-dir=.nyc_output --reporter=text-summary --cwd=. --exclude-after-remap false"
   },
   "dependencies": {
-    "@heartexlabs/ls-test": "heartexlabs/ls-frontend-test#a771403374e3d2809b7d818bd33c0cc183bc97ab"
+    "@heartexlabs/ls-test": "heartexlabs/ls-frontend-test#2a8ade2c44636ba1b263222b6338928e5b7ce919"
   },
   "devDependencies": {
     "ts-loader": "^9.4.2",

--- a/tests/functional/specs/control_tags/taxonomy.cy.ts
+++ b/tests/functional/specs/control_tags/taxonomy.cy.ts
@@ -1,4 +1,4 @@
-import { LabelStudio, Tooltip } from '@heartexlabs/ls-test/helpers/LSF/index';
+import { LabelStudio, ToolBar, Tooltip } from '@heartexlabs/ls-test/helpers/LSF/index';
 import { useTaxonomy } from '@heartexlabs/ls-test/helpers/LSF';
 import {
   buildDynamicTaxonomyConfig,
@@ -128,8 +128,8 @@ Object.entries(taxonomies).forEach(([title, Taxonomy]) => {
 
           init(config, data);
           // create new annotation and check that preselected choices are selected already
-          cy.get('.lsf-annotations-list').click();
-          cy.get('.lsf-annotations-list__create').click();
+          ToolBar.toggleAnnotationsList();
+          ToolBar.createNewAnnotation();
           Taxonomy.open();
           Taxonomy.hasSelected('Choice 3');
         });

--- a/tests/functional/specs/relations/basic.cy.ts
+++ b/tests/functional/specs/relations/basic.cy.ts
@@ -1,10 +1,10 @@
-import { ImageView, LabelStudio, Relations } from '@heartexlabs/ls-test/helpers/LSF';
+import { ImageView, LabelStudio, Relations, ToolBar } from '@heartexlabs/ls-test/helpers/LSF';
 import {
   imageConfigWithRelations,
   simpleImageConfig,
   simpleImageData,
   simpleImageResultWithRelation,
-  simpleImageResultWithRelations, simpleImageResultWithRelationsAndLabels
+  simpleImageResultWithRelations, simpleImageResultWithRelationsAndLabels, simpleImageResultWithRelationsAndLabelsAlt
 } from '../../data/relations/basic';
 
 describe('Relations: Basic', () => {
@@ -120,6 +120,48 @@ describe('Relations: Basic', () => {
 
     Relations.hoverRelation(0);
     Relations.clickShowRelationLabels(0);
+    Relations.hasRelationLabels(['Blue label', 'Red label'], 0);
+  });
+
+  it('should rerender relation labels input on annotation switching', () => {
+    LabelStudio.params()
+      .config(imageConfigWithRelations)
+      .data(simpleImageData)
+      .withAnnotation({
+        id: 2,
+        result: simpleImageResultWithRelationsAndLabelsAlt,
+      })
+      .withAnnotation({
+        id: 1,
+        result: simpleImageResultWithRelationsAndLabels,
+      })
+      .init();
+
+    ImageView.waitForImage();
+
+    Relations.hasRelations(1);
+
+    // open relation labels
+    Relations.hoverRelation(0);
+    Relations.clickShowRelationLabels(0);
+
+    // open annotation list
+    ToolBar.toggleAnnotationsList();
+    // switch to the second annotation
+    ToolBar.selectAnnotation(1);
+
+    // open relation labels as well
+    Relations.hoverRelation(0);
+    Relations.clickShowRelationLabels(0);
+
+    // just check the current state
+    Relations.hasRelationLabels(['Green label'], 0);
+
+    // go to the first annotation
+    ToolBar.toggleAnnotationsList();
+    ToolBar.selectAnnotation(0);
+
+    // check that relations in the input are changed according to the first annotation result
     Relations.hasRelationLabels(['Blue label', 'Red label'], 0);
   });
 });

--- a/tests/functional/specs/relations/basic.cy.ts
+++ b/tests/functional/specs/relations/basic.cy.ts
@@ -2,7 +2,7 @@ import { ImageView, LabelStudio, Relations, ToolBar } from '@heartexlabs/ls-test
 import {
   imageConfigWithRelations,
   simpleImageConfig,
-  simpleImageData,
+  simpleImageData, simpleImageResult,
   simpleImageResultWithRelation,
   simpleImageResultWithRelations, simpleImageResultWithRelationsAndLabels, simpleImageResultWithRelationsAndLabelsAlt
 } from '../../data/relations/basic';
@@ -163,5 +163,157 @@ describe('Relations: Basic', () => {
 
     // check that relations in the input are changed according to the first annotation result
     Relations.hasRelationLabels(['Blue label', 'Red label'], 0);
+  });
+
+  it('Should create correct step in history by adding relation', () => {
+    LabelStudio.params()
+      .config(simpleImageConfig)
+      .data(simpleImageData)
+      .withResult(simpleImageResult)
+      .init();
+
+    ImageView.waitForImage();
+
+    Relations.hasRelations(0);
+
+    ImageView.clickAtRelative(.30, .30);
+    Relations.toggleCreationWithHotkey();
+    ImageView.clickAtRelative(.60, .60);
+
+    cy.window().then((win) => {
+      expect(win.Htx.annotationStore.selected.history.history.length).to.equal(2);
+    });
+
+    cy.get('body').type('{ctrl+z}');
+    Relations.hasRelations(0);
+    cy.get('body').type('{ctrl+shift+z}');
+    Relations.hasRelations(1);
+    cy.window().then((win) => {
+      expect(win.Htx.annotationStore.selected.history.history.length).to.equal(2);
+    });
+  });
+
+  it('Should create correct step in history by deleting relation', () => {
+    LabelStudio.params()
+      .config(simpleImageConfig)
+      .data(simpleImageData)
+      .withResult(simpleImageResultWithRelation)
+      .init();
+
+    ImageView.waitForImage();
+
+    Relations.hasRelations(1);
+    cy.window().then((win) => {
+      expect(win.Htx.annotationStore.selected.history.history.length).to.equal(1);
+    });
+
+    Relations.deleteRelationAction(0);
+
+    Relations.hasRelations(0);
+    cy.window().then((win) => {
+      expect(win.Htx.annotationStore.selected.history.history.length).to.equal(2);
+    });
+
+    cy.get('body').type('{ctrl+z}');
+    Relations.hasRelations(1);
+    cy.window().then((win) => {
+      expect(win.Htx.annotationStore.selected.history.history.length).to.equal(2);
+    });
+
+    cy.get('body').type('{ctrl+shift+z}');
+    Relations.hasRelations(0);
+    cy.window().then((win) => {
+      expect(win.Htx.annotationStore.selected.history.history.length).to.equal(2);
+    });
+  });
+
+  it('Should create correct step in history by changing relation direction', () => {
+    LabelStudio.params()
+      .config(simpleImageConfig)
+      .data(simpleImageData)
+      .withResult(simpleImageResultWithRelation)
+      .init();
+
+    ImageView.waitForImage();
+
+    Relations.hasRelations(1);
+    cy.window().then((win) => {
+      expect(win.Htx.annotationStore.selected.history.history.length).to.equal(1);
+    });
+
+    Relations.toggleRelationDirection(0);
+
+    Relations.hasRelations(1);
+    cy.window().then((win) => {
+      expect(win.Htx.annotationStore.selected.history.history.length).to.equal(2);
+    });
+  });
+
+  it('Should create correct step in history by adding label to relation', () => {
+    LabelStudio.params()
+      .config(imageConfigWithRelations)
+      .data(simpleImageData)
+      .withResult(simpleImageResultWithRelation)
+      .init();
+
+    ImageView.waitForImage();
+
+    Relations.hasRelations(1);
+    Relations.hoverOverRelation(0);
+    Relations.clickShowRelationLabels(0);
+    Relations.addLabelToRelation('Blue label', 0);
+    Relations.hasRelationLabels(['Blue label'], 0);
+    cy.window().then((win) => {
+      expect(win.Htx.annotationStore.selected.history.history.length).to.equal(2);
+    });
+
+    cy.get('body').type('{ctrl+z}');
+    Relations.hasRelationLabels([], 0);
+    cy.window().then((win) => {
+      expect(win.Htx.annotationStore.selected.history.history.length).to.equal(2);
+    });
+
+    cy.get('body').type('{ctrl+shift+z}');
+    Relations.hasRelationLabels(['Blue label'], 0);
+    cy.window().then((win) => {
+      expect(win.Htx.annotationStore.selected.history.history.length).to.equal(2);
+    });
+  });
+
+  it('Should not create step in history by highlighting relation', () => {
+    LabelStudio.params()
+      .config(simpleImageConfig)
+      .data(simpleImageData)
+      .withResult(simpleImageResultWithRelation)
+      .init();
+
+    ImageView.waitForImage();
+
+    Relations.hoverOverRelation(0);
+    Relations.stopHoveringOverRelation(0);
+
+    cy.window().then((win) => {
+      expect(win.Htx.annotationStore.selected.history.history.length).to.equal(1);
+    });
+  });
+
+  it('Should not create step in history by hiding relation', () => {
+    LabelStudio.params()
+      .config(simpleImageConfig)
+      .data(simpleImageData)
+      .withResult(simpleImageResultWithRelation)
+      .init();
+
+    ImageView.waitForImage();
+
+    Relations.hasRelations(1);
+    cy.window().then((win) => {
+      expect(win.Htx.annotationStore.selected.history.history.length).to.equal(1);
+    });
+
+    Relations.hideRelationAction(0);
+    cy.window().then((win) => {
+      expect(win.Htx.annotationStore.selected.history.history.length).to.equal(1);
+    });
   });
 });

--- a/tests/functional/specs/relations/basic.cy.ts
+++ b/tests/functional/specs/relations/basic.cy.ts
@@ -97,12 +97,12 @@ describe('Relations: Basic', () => {
 
     ImageView.waitForImage();
 
-    Relations.hoverRelation(0);
+    Relations.hoverOverRelation(0);
     Relations.clickShowRelationLabels(0);
 
     Relations.hasRelationLabels([], 0);
 
-    Relations.addRelationLabel('Blue label', 0);
+    Relations.addLabelToRelation('Blue label', 0);
 
     Relations.hasRelationLabels(['Blue label'], 0);
   });
@@ -118,7 +118,7 @@ describe('Relations: Basic', () => {
 
     Relations.hasRelations(1);
 
-    Relations.hoverRelation(0);
+    Relations.hoverOverRelation(0);
     Relations.clickShowRelationLabels(0);
     Relations.hasRelationLabels(['Blue label', 'Red label'], 0);
   });
@@ -142,7 +142,7 @@ describe('Relations: Basic', () => {
     Relations.hasRelations(1);
 
     // open relation labels
-    Relations.hoverRelation(0);
+    Relations.hoverOverRelation(0);
     Relations.clickShowRelationLabels(0);
 
     // open annotation list
@@ -151,7 +151,7 @@ describe('Relations: Basic', () => {
     ToolBar.selectAnnotation(1);
 
     // open relation labels as well
-    Relations.hoverRelation(0);
+    Relations.hoverOverRelation(0);
     Relations.clickShowRelationLabels(0);
 
     // just check the current state

--- a/tests/functional/specs/relations/basic.cy.ts
+++ b/tests/functional/specs/relations/basic.cy.ts
@@ -1,0 +1,125 @@
+import { ImageView, LabelStudio, Relations } from '@heartexlabs/ls-test/helpers/LSF';
+import {
+  imageConfigWithRelations,
+  simpleImageConfig,
+  simpleImageData,
+  simpleImageResultWithRelation,
+  simpleImageResultWithRelations, simpleImageResultWithRelationsAndLabels
+} from '../../data/relations/basic';
+
+describe('Relations: Basic', () => {
+  it('should load relations from the result', () => {
+    LabelStudio.params()
+      .config(simpleImageConfig)
+      .data(simpleImageData)
+      .withResult(simpleImageResultWithRelation)
+      .init();
+
+    ImageView.waitForImage();
+
+    Relations.hasRelations(1);
+    Relations.hasRelation('Region', 'Region');
+  });
+
+  it('should display direction correctly', () => {
+    LabelStudio.params()
+      .config(simpleImageConfig)
+      .data(simpleImageData)
+      .withResult(simpleImageResultWithRelations)
+      .init();
+
+    ImageView.waitForImage();
+
+    Relations.hasRelations(3);
+    Relations.hasRelationDirection('right', 0);
+    Relations.hasRelationDirection('left', 1);
+    Relations.hasRelationDirection('bi', 2);
+  });
+
+  it('should toggle direction', () => {
+    LabelStudio.params()
+      .config(simpleImageConfig)
+      .data(simpleImageData)
+      .withResult(simpleImageResultWithRelation)
+      .init();
+
+    ImageView.waitForImage();
+
+    Relations.hasRelations(1);
+    Relations.hasRelationDirection('right', 0);
+    Relations.toggleRelationDirection(0);
+    Relations.hasRelationDirection('bi', 0);
+    Relations.toggleRelationDirection(0);
+    Relations.hasRelationDirection('left', 0);
+    Relations.toggleRelationDirection(0);
+    Relations.hasRelationDirection('right', 0);
+  });
+
+  it('should hide/show relation', () => {
+    LabelStudio.params()
+      .config(simpleImageConfig)
+      .data(simpleImageData)
+      .withResult(simpleImageResultWithRelation)
+      .init();
+
+    ImageView.waitForImage();
+
+    Relations.hasRelations(1);
+    Relations.isNotHiddenRelation(0);
+    Relations.hideRelationAction(0);
+    Relations.hasRelations(1);
+    Relations.isHiddenRelation(0);
+    Relations.showRelationAction(0);
+    Relations.hasRelations(1);
+    Relations.isNotHiddenRelation(0);
+  });
+
+  it('should delete relation', () => {
+    LabelStudio.params()
+      .config(simpleImageConfig)
+      .data(simpleImageData)
+      .withResult(simpleImageResultWithRelation)
+      .init();
+
+    ImageView.waitForImage();
+
+    Relations.hasRelations(1);
+    Relations.deleteRelationAction(0);
+    Relations.hasRelations(0);
+  });
+
+  it('should set relation label', () => {
+    LabelStudio.params()
+      .config(imageConfigWithRelations)
+      .data(simpleImageData)
+      .withResult(simpleImageResultWithRelation)
+      .init();
+
+    ImageView.waitForImage();
+
+    Relations.hoverRelation(0);
+    Relations.clickShowRelationLabels(0);
+
+    Relations.hasRelationLabels([], 0);
+
+    Relations.addRelationLabel('Blue label', 0);
+
+    Relations.hasRelationLabels(['Blue label'], 0);
+  });
+
+  it('should load relation with labels', () => {
+    LabelStudio.params()
+      .config(imageConfigWithRelations)
+      .data(simpleImageData)
+      .withResult(simpleImageResultWithRelationsAndLabels)
+      .init();
+
+    ImageView.waitForImage();
+
+    Relations.hasRelations(1);
+
+    Relations.hoverRelation(0);
+    Relations.clickShowRelationLabels(0);
+    Relations.hasRelationLabels(['Blue label', 'Red label'], 0);
+  });
+});

--- a/tests/functional/specs/video_segmentation/regions.cy.ts
+++ b/tests/functional/specs/video_segmentation/regions.cy.ts
@@ -2,7 +2,7 @@ import { Labels, LabelStudio, Sidebar, VideoView } from '@heartexlabs/ls-test/he
 import { simpleVideoConfig, simpleVideoData, simpleVideoResult } from 'data/video_segmentation/regions';
 
 describe('Video segmentation', () => {
-  it('Should be able to draw a simple rectangle', ()=>{
+  it('Should be able to draw a simple rectangle', () => {
     LabelStudio.params()
       .config(simpleVideoConfig)
       .data(simpleVideoData)
@@ -36,7 +36,7 @@ describe('Video segmentation', () => {
   });
 
   describe('Rectangle', () => {
-    it('Should be invisible out of the lifespan', () =>{
+    it('Should be invisible out of the lifespan', () => {
       LabelStudio.params()
         .config(simpleVideoConfig)
         .data(simpleVideoData)
@@ -52,7 +52,7 @@ describe('Video segmentation', () => {
   });
 
   describe('Transformer', () => {
-    it.only('Should be invisible out of the lifespan', () =>{
+    it('Should be invisible out of the lifespan', () => {
       LabelStudio.params()
         .config(simpleVideoConfig)
         .data(simpleVideoData)

--- a/tests/functional/yarn.lock
+++ b/tests/functional/yarn.lock
@@ -264,9 +264,9 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
 
-"@heartexlabs/ls-test@heartexlabs/ls-frontend-test#2a8ade2c44636ba1b263222b6338928e5b7ce919":
+"@heartexlabs/ls-test@heartexlabs/ls-frontend-test#70666737e54c15edb505a0986d2ca3c4f15c57b3":
   version "1.0.8"
-  resolved "https://codeload.github.com/heartexlabs/ls-frontend-test/tar.gz/2a8ade2c44636ba1b263222b6338928e5b7ce919"
+  resolved "https://codeload.github.com/heartexlabs/ls-frontend-test/tar.gz/70666737e54c15edb505a0986d2ca3c4f15c57b3"
   dependencies:
     "@cypress/code-coverage" "^3.10.0"
     "@cypress/webpack-preprocessor" "^5.17.0"

--- a/tests/functional/yarn.lock
+++ b/tests/functional/yarn.lock
@@ -288,9 +288,9 @@
     webpack-cli "^5.0.1"
     yargs "^17.7.1"
 
-"@heartexlabs/ls-test@heartexlabs/ls-frontend-test#a771403374e3d2809b7d818bd33c0cc183bc97ab":
+"@heartexlabs/ls-test@heartexlabs/ls-frontend-test#82ed8ce353a84a087f285a107f86768bbcb3e133":
   version "1.0.8"
-  resolved "https://codeload.github.com/heartexlabs/ls-frontend-test/tar.gz/a771403374e3d2809b7d818bd33c0cc183bc97ab"
+  resolved "https://codeload.github.com/heartexlabs/ls-frontend-test/tar.gz/82ed8ce353a84a087f285a107f86768bbcb3e133"
   dependencies:
     "@cypress/code-coverage" "^3.10.0"
     "@cypress/webpack-preprocessor" "^5.17.0"

--- a/tests/functional/yarn.lock
+++ b/tests/functional/yarn.lock
@@ -264,9 +264,9 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
 
-"@heartexlabs/ls-test@heartexlabs/ls-frontend-test#a771403374e3d2809b7d818bd33c0cc183bc97ab":
+"@heartexlabs/ls-test@heartexlabs/ls-frontend-test#2a8ade2c44636ba1b263222b6338928e5b7ce919":
   version "1.0.8"
-  resolved "https://codeload.github.com/heartexlabs/ls-frontend-test/tar.gz/a771403374e3d2809b7d818bd33c0cc183bc97ab"
+  resolved "https://codeload.github.com/heartexlabs/ls-frontend-test/tar.gz/2a8ade2c44636ba1b263222b6338928e5b7ce919"
   dependencies:
     "@cypress/code-coverage" "^3.10.0"
     "@cypress/webpack-preprocessor" "^5.17.0"
@@ -288,9 +288,9 @@
     webpack-cli "^5.0.1"
     yargs "^17.7.1"
 
-"@heartexlabs/ls-test@heartexlabs/ls-frontend-test#ebac21c25d27acb608516d24cb74547c548caa4e":
+"@heartexlabs/ls-test@heartexlabs/ls-frontend-test#a771403374e3d2809b7d818bd33c0cc183bc97ab":
   version "1.0.8"
-  resolved "https://codeload.github.com/heartexlabs/ls-frontend-test/tar.gz/ebac21c25d27acb608516d24cb74547c548caa4e"
+  resolved "https://codeload.github.com/heartexlabs/ls-frontend-test/tar.gz/a771403374e3d2809b7d818bd33c0cc183bc97ab"
   dependencies:
     "@cypress/code-coverage" "^3.10.0"
     "@cypress/webpack-preprocessor" "^5.17.0"

--- a/tests/functional/yarn.lock
+++ b/tests/functional/yarn.lock
@@ -288,9 +288,9 @@
     webpack-cli "^5.0.1"
     yargs "^17.7.1"
 
-"@heartexlabs/ls-test@heartexlabs/ls-frontend-test#82ed8ce353a84a087f285a107f86768bbcb3e133":
+"@heartexlabs/ls-test@heartexlabs/ls-frontend-test#e760e117af39c187065ec8c704ce174e5d001eff":
   version "1.0.8"
-  resolved "https://codeload.github.com/heartexlabs/ls-frontend-test/tar.gz/82ed8ce353a84a087f285a107f86768bbcb3e133"
+  resolved "https://codeload.github.com/heartexlabs/ls-frontend-test/tar.gz/e760e117af39c187065ec8c704ce174e5d001eff"
   dependencies:
     "@cypress/code-coverage" "^3.10.0"
     "@cypress/webpack-preprocessor" "^5.17.0"


### PR DESCRIPTION
### PR fulfills these requirements
- [x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [x] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)

#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [x] Frontend

### Describe the reason for change
Previously, TimeTraveler and Relations worked separately. This led to a number of problems when they were used together. Moreover, it violated UX principles. Besides that, the implementation of Relations was based on an legacy paradigm, which was redundant and not entirely suitable. The decision was made to rewrite this functionality to eliminate the described problems.

#### What does this fix?
This fix enables Relations to operate in the context of change history and with undo/redo functionality. It also eliminates the legacy approach to storing the state of Relation.

#### What is the new behavior?
Now you can undo changes in Relations as it works for regions. 

#### Does this change affect performance?
This may improve performance, as we are reducing the number of traversals through the tag tree and also not creating unnecessary entities in `mst`.

#### Does this change affect security?
Nope

#### What alternative approaches were there?
N/A

#### What feature flags were used to cover this change?
All alternative approaches did not imply an improvement of the current situation and did not enhance UX. Therefore, they could be classified as unreasonable.

### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [ ] No
- [x] Not sure (briefly explain the situation below)

It's reworking of the code.  There is no guarantee that all previously existing functionality has been taken into account.

### What level of testing was included in the change?
_(check all that apply)_
- [ ] e2e
- [x] integration
- [ ] unit

### Which logical domain(s) does this change affect?
`Relations`, `TimeTraveler`