### PR TITLE
fix: OPTIC-341: CSS inconsistencies which cause conflicts in MonoRepo builds

### DIFF
--- a/src/components/BottomBar/Controls.styl
+++ b/src/components/BottomBar/Controls.styl
@@ -98,7 +98,7 @@
     &__footer
       display flex
       flex-direction row
-      justify-content end
+      justify-content flex-end
 
 .submit-option
   padding 12px 24px

--- a/src/components/Comments/CommentForm.styl
+++ b/src/components/Comments/CommentForm.styl
@@ -16,7 +16,7 @@
         width 100%
         display flex
         justify-content center
-        align-items start
+        align-items flex-start
         flex-shrink 0
         flex-grow 0
 

--- a/src/components/SidePanels/TabPanels/PanelTabsBase.styl
+++ b/src/components/SidePanels/TabPanels/PanelTabsBase.styl
@@ -1,5 +1,5 @@
 .tabs-panel
-  --header-height: 24px
+  --header-height 24px
   --header-border-radius 0
   --header-background #e1e0e2
   --icon-color #898098
@@ -19,10 +19,10 @@
   &__header-right,
   &__header-left
     display flex
-    alignItems center 
+    align-items center
 
   &__header-left
-    pointerEvents: none
+    pointer-events none
 
   &_alignment
     &_left
@@ -40,7 +40,7 @@
     left 0
     position absolute
     border 1px solid rgba(137, 128, 152, 0.16)
-    box-shadow: 0px 6px 10px 4px rgba(38, 38, 38, 0.15), 0px 2px 3px rgba(38, 38, 38, 0.3);
+    box-shadow 0px 6px 10px 4px rgba(38, 38, 38, 0.15), 0px 2px 3px rgba(38, 38, 38, 0.3);
 
   &_hidden
     top 0

--- a/src/components/TopBar/Controls.styl
+++ b/src/components/TopBar/Controls.styl
@@ -48,4 +48,4 @@
     &__footer
       display flex
       flex-direction row
-      justify-content end
+      justify-content flex-end


### PR DESCRIPTION
### PR fulfills these requirements
- [X] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [X] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [X] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [X] Frontend



### Describe the reason for change
In the movement to MonoRepo, there were some observed idiosyncrasies in the css build output. After looking further into why, it appeared there were some incorrect syntax being used previously that our old builds were tolerant to, however newer libraries no longer allow this and the output css had incorrect or missing values as a result causing minor issues in the UI. This just fixes the upstream issues so it can be corrected for the monorepo and existing codebase here.