### PR TITLE
fix: OPTIC-341: Incorrect icon width causing layout issues with TabPanels in monorepo

### DIFF
--- a/src/components/SidePanels/TabPanels/PanelTabsBase.tsx
+++ b/src/components/SidePanels/TabPanels/PanelTabsBase.tsx
@@ -257,7 +257,7 @@ export const PanelTabsBase: FC<BaseProps> = ({
             {isChildOfGroup && visible && <Elem name="grouped-top" ref={resizeGroup} mod={{ drag: 'grouped-top' === resizing }} data-resize={'grouped-top'} />}
             <Elem ref={headerRef} onClick={() => { if (collapsed) handleGroupPanelToggle(); }} id={key} mod={{ collapsed }} name="header">
               <Elem name="header-left">
-                {!collapsed && <Elem name="icon" style={{ pointerEvents: 'none' }} tag={IconOutlinerDrag} width={20} />}
+                {!collapsed && <Elem name="icon" style={{ pointerEvents: 'none' }} tag={IconOutlinerDrag} width={8} />}
                 {!visible && !collapsed && <Elem name="title">{panelViews.map(view => view.title).join(' ')}</Elem>}
               </Elem>
               <Elem name="header-right" >

--- a/src/components/SidePanels/TabPanels/Tabs.tsx
+++ b/src/components/SidePanels/TabPanels/Tabs.tsx
@@ -158,7 +158,7 @@ const Tab = ({
 
   const Label = () => (
     <Elem id={`${panelKey}_${tabIndex}_droppable`} name="tab" mod={{ active: locked ? tabIndex === breakPointActiveTab : active }}>
-      {!locked && <Elem name="icon" tag={IconOutlinerDrag} width={20} />}
+      {!locked && <Elem name="icon" tag={IconOutlinerDrag} width={8} />}
       {tabText}
     </Elem>
   );


### PR DESCRIPTION
## Reason for change

The actual icon width is 8px, and we were putting 20px. This has caused more style issues observed when running the application within MonoRepo context, and should operate correctly regardless of build output if we align the widths correctly.