### PR TITLE
fix: LEAP-368: Don't add `hidden` and `locked` to undo history

### DIFF
--- a/src/mixins/Regions.js
+++ b/src/mixins/Regions.js
@@ -12,8 +12,6 @@ const RegionsMixin = types
 
     score: types.maybeNull(types.number),
 
-    hidden: types.optional(types.boolean, false),
-
     filtered: types.optional(types.boolean, false),
 
     parentID: types.optional(types.string, ''),
@@ -36,6 +34,7 @@ const RegionsMixin = types
   .volatile(() => ({
     // selected: false,
     _highlighted: false,
+    hidden: false,
     isDrawing: false,
     perRegionFocusRequest: null,
     shapeRef: null,

--- a/src/mixins/Regions.js
+++ b/src/mixins/Regions.js
@@ -21,8 +21,6 @@ const RegionsMixin = types
     // Dynamic preannotations enabled
     dynamic: false,
 
-    locked: false,
-
     origin: types.optional(types.enumeration([
       'prediction',
       'prediction-changed',
@@ -35,6 +33,7 @@ const RegionsMixin = types
     // selected: false,
     _highlighted: false,
     hidden: false,
+    locked: false,
     isDrawing: false,
     perRegionFocusRequest: null,
     shapeRef: null,


### PR DESCRIPTION
Very simple fix. But there is a new UX problem them: if you undo/redo actions done to hidden regions you see no changes on the screen, previously region became visible at some point and only then undo went through actual actions.

### PR fulfills these requirements
- [ ] Tests for the changes have been added/updated
- [ ] Docs have been added/updated
- [ ] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance

### What feature flags were used to cover this change?
none — maybe we need this to cover UX change

### What alternative approaches were there?

### This change affects (describe how if yes)
- [ ] Performance
- [ ] Security
- [x] UX — undo/redo over hidden regions now is not visible, that's confusing

### Does this PR introduce a breaking change?
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [x] No
- [ ] Not sure (briefly explain the situation below)

### What level of testing was included in the change?
- [ ] e2e (codecept)
- [ ] integration (cypress)
- [ ] unit (jest)
