### PR TITLE
fix: LEAP-466: Don't sanitize text tasks

### DIFF
--- a/src/tags/object/RichText/model.js
+++ b/src/tags/object/RichText/model.js
@@ -221,7 +221,9 @@ const Model = types
         // clean up the html — remove scripts and iframes
         // nodes count better be the same, so replace them with stubs
         // we should not sanitize text tasks because we already have htmlEscape in view.js
-        if (!isFF(FF_SAFE_TEXT) || self.type !== 'text') {
+        if (isFF(FF_SAFE_TEXT) && self.type === 'text') {
+          self._value = val;
+        } else {
           self._value = sanitizeHtml(String(val));
         }
 

--- a/src/tags/object/RichText/model.js
+++ b/src/tags/object/RichText/model.js
@@ -14,7 +14,7 @@ import { findRangeNative, rangeToGlobalOffset } from '../../../utils/selection-t
 import { escapeHtml, isValidObjectURL } from '../../../utils/utilities';
 import ObjectBase from '../Base';
 import { cloneNode } from '../../../core/Helpers';
-import { FF_LSDV_4620_3, isFF } from '../../../utils/feature-flags';
+import { FF_LSDV_4620_3, FF_SAFE_TEXT, isFF } from '../../../utils/feature-flags';
 import DomManager from './domManager';
 import { STATE_CLASS_MODS } from '../../../mixins/HighlightMixin';
 import Constants from '../../../core/Constants';
@@ -220,7 +220,10 @@ const Model = types
 
         // clean up the html — remove scripts and iframes
         // nodes count better be the same, so replace them with stubs
-        self._value = sanitizeHtml(String(val));
+        // we should not sanitize text tasks because we already have htmlEscape in view.js
+        if (!isFF(FF_SAFE_TEXT) || self.type !== 'text') {
+          self._value = sanitizeHtml(String(val));
+        }
 
         self._regionsCache.forEach(({ region, annotation }) => {
           region.setText(self._value.substring(region.startOffset, region.endOffset));

--- a/src/utils/feature-flags.ts
+++ b/src/utils/feature-flags.ts
@@ -331,6 +331,8 @@ export const FF_LEAP_187 = 'fflag_feat_front_leap_187_video_seek_on_select_short
  */
 export const FF_ZOOM_OPTIM = 'fflag_fix_front_leap_32_zoom_perf_190923_short';
 
+export const FF_SAFE_TEXT = 'fflag_fix_leap_466_text_sanitization';
+
 
 Object.assign(window, {
   APP_SETTINGS: {


### PR DESCRIPTION
We already fully sanitize text in view.js with htmlEscape, so it's safe.

### PR fulfills these requirements
- [ ] Tests for the changes have been added/updated
- [ ] Docs have been added/updated
- [ ] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance

### Describe the reason for change
We improved html sanitization and this new library started to convert `&` and lonely `>` to html-entites, shifting offsets of the following regions.

### What feature flags were used to cover this change?
`fflag_fix_leap_466_text_sanitization`

### What alternative approaches were there?
To fix the library or its params and we might need it if html tasks are also affected.

### This change affects (describe how if yes)
- [ ] Performance
- [ ] Security
- [ ] UX

### Does this PR introduce a breaking change?
- [ ] Yes, and covered entirely by feature flag(s)
- [x] Yes, and covered partially by feature flag(s)
- [ ] No
- [ ] Not sure (briefly explain the situation below)

### What level of testing was included in the change?
- [ ] e2e (codecept)
- [ ] integration (cypress)
- [ ] unit (jest)