### PR TITLE
fix: LEAP-381: Remove excess regexp from BEM module

### DIFF
--- a/src/utils/bem.ts
+++ b/src/utils/bem.ts
@@ -111,8 +111,10 @@ const assembleClass = (block: string, elem?: string, mix?: CNMix | CNMix[], mod?
     finalClass.push(...Array.from(new Set(mixMap)));
   }
 
-  const attachNamespace = (cls: string) =>
-    cls.startsWith(CSS_PREFIX) ? cls : `${CSS_PREFIX}${cls}`;
+  const attachNamespace = (cls: string) => {
+    if (typeof cls !== 'string') console.error('Non-string classname: ', cls);
+    return String(cls).startsWith(CSS_PREFIX) ? cls : `${CSS_PREFIX}${cls}`;
+  };
 
   return finalClass.map(attachNamespace).join(' ');
 };

--- a/src/utils/bem.ts
+++ b/src/utils/bem.ts
@@ -111,10 +111,8 @@ const assembleClass = (block: string, elem?: string, mix?: CNMix | CNMix[], mod?
     finalClass.push(...Array.from(new Set(mixMap)));
   }
 
-  const attachNamespace = (cls: string) => {
-    if (new RegExp(CSS_PREFIX).test(cls)) return cls;
-    else return `${CSS_PREFIX}${cls}`;
-  };
+  const attachNamespace = (cls: string) =>
+    cls.startsWith(CSS_PREFIX) ? cls : `${CSS_PREFIX}${cls}`;
 
   return finalClass.map(attachNamespace).join(' ');
 };


### PR DESCRIPTION
It's not used in LSF anyway. And the fix is pretty simple and straightforward.

### PR fulfills these requirements
- [ ] Tests for the changes have been added/updated
- [ ] Docs have been added/updated
- [ ] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance

### Describe the reason for change
To fix regexp injection vulnerability https://github.com/HumanSignal/label-studio-frontend/security/code-scanning/9

### This change affects (describe how if yes)
- [ ] Performance
- [x] Security
- [ ] UX

### Does this PR introduce a breaking change?
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [x] No
- [ ] Not sure (briefly explain the situation below)

### What level of testing was included in the change?
- [ ] e2e (codecept)
- [ ] integration (cypress)
- [ ] unit (jest)
