### PR TITLE
fix: LEAP-248: Fix app crashing by hotkeys 

### DIFF
--- a/src/core/Hotkey.ts
+++ b/src/core/Hotkey.ts
@@ -82,6 +82,7 @@ keymaster.filter = function(event) {
 const ALIASES = {
   'plus': '=', // "ctrl plus" is actually a "ctrl =" because shift is not used
   'minus': '-',
+  ',': '¼', // This should be a comma but it's not working with keymaster
 };
 
 export const Hotkey = (
@@ -175,8 +176,9 @@ export const Hotkey = (
 
   return {
     applyAliases(key: string) {
-      return key
-        .split(',')
+      const keys = getKeys(key);
+
+      return keys
         .map(k => k.split('+').map(k => ALIASES[k.trim()] ?? k).join('+'))
         .join(',');
     },

--- a/src/core/Hotkey.ts
+++ b/src/core/Hotkey.ts
@@ -144,17 +144,27 @@ export const Hotkey = (
     });
   };
 
+  const getKeys = (key: string) => {
+    const tokenRegex = /((?:\w+\+)*(?:[^,]+|,)),?/g;
+
+    return [...key.replace(/\s/,'').matchAll(tokenRegex)].map(match => match[1]);
+  };
+
   const unbind = () => {
     for (const scope of [DEFAULT_SCOPE, INPUT_SCOPE]) {
       for (const key of Object.keys(_hotkeys_map)) {
-        if (isFF(FF_LSDV_1148)) {
-          removeKeyHandlerRef(scope, key);
-          keymaster.unbind(key, scope);
-          rebindKeyHandlers(scope, key);
-        } else {
-          keymaster.unbind(key, scope);
+        const keys = getKeys(key);
+
+        for (const key of keys) {
+          if (isFF(FF_LSDV_1148)) {
+            removeKeyHandlerRef(scope, key);
+            keymaster.unbind(key, scope);
+            rebindKeyHandlers(scope, key);
+          } else {
+            keymaster.unbind(key, scope);
+          }
+          delete _hotkeys_desc[key];
         }
-        delete _hotkeys_desc[key];
       }
     }
 

--- a/src/core/Hotkey.ts
+++ b/src/core/Hotkey.ts
@@ -82,7 +82,9 @@ keymaster.filter = function(event) {
 const ALIASES = {
   'plus': '=', // "ctrl plus" is actually a "ctrl =" because shift is not used
   'minus': '-',
-  ',': '¼', // This should be a comma but it's not working with keymaster
+  // Here is a magic trick. Keymaster doesn't work with comma correctly (it breaks down everything upon unbinding), but the key code for comma it expects is 188
+  // And the magic is that '¼' has the same keycode. So we are going to trick keymaster to handle this in the right way.
+  ',': '¼',
 };
 
 export const Hotkey = (

--- a/tests/functional/data/core/hotkeys.ts
+++ b/tests/functional/data/core/hotkeys.ts
@@ -1,0 +1,6 @@
+export const createConfigWithHotkey = (hotkey: string) => `<View>
+  <Image name="img" value="$image"/>
+  <RectangleLabels name="tag" toName="img">
+    <Label value="Label" hotkey="${hotkey}" />
+  </RectangleLabels>
+</View>`;

--- a/tests/functional/specs/core/hotkeys.cy.ts
+++ b/tests/functional/specs/core/hotkeys.cy.ts
@@ -1,0 +1,68 @@
+import { Labels, LabelStudio } from '../../../../../../ls-frontend-test/helpers/LSF';
+import {
+  createConfigWithHotkey
+} from '../../data/core/hotkeys';
+import { Generator } from '../../../../../../ls-frontend-test/helpers/common/Generator';
+
+describe('Hotkeys', () => {
+  const hotkeysToCheck = [
+    ['L', 'r'],
+    ['ctrl+L', 'ctrl+r'],
+    [','],
+    [',',',',','], // it won't work with odd number of commas 'cause 2 calls of selecting label cancel each other
+    ['a',','],
+    [',','b'],
+    ['a',',','b'],
+    ['ctrl+,','ctrl+.'],
+    ['ctrl+.','ctrl+,'],
+  ];
+
+  for (const hotkeys of hotkeysToCheck) {
+    const hotkeyString = hotkeys.join(',');
+
+    it(`should be able to use hotkey ${hotkeyString}`, () => {
+      Generator.generateImageUrl({ width: 800, height: 50 })
+        .then(imageUrl => {
+          LabelStudio.params()
+            .config(createConfigWithHotkey(hotkeyString))
+            .data({ image: imageUrl })
+            .withResult([])
+            .init();
+        });
+
+      LabelStudio.waitForObjectsReady();
+      Labels.label.should('have.length', 1);
+
+      cy.log('Check that hotkeys work');
+      for (const hotkey of hotkeys) {
+        const hotkeyInput = hotkey.includes('+') ? `{${hotkey}}` : `${hotkey}`;
+
+        // try to use hotkey
+        cy.get('body').type(hotkeyInput);
+        Labels.selectedLabel.contains('Label');
+        // deselect
+        cy.get('body').type('{esc}');
+      }
+
+      cy.log('Reload LS');
+      cy.window().then(win => {
+        win.LabelStudio.destroyAll();
+        new win.LabelStudio('label-studio', win.LSF_CONFIG);
+      });
+
+      LabelStudio.waitForObjectsReady();
+      Labels.label.should('have.length', 1);
+
+      cy.log('Check that hotkeys still work');
+      for (const hotkey of hotkeys) {
+        const hotkeyInput = hotkey.includes('+') ? `{${hotkey}}` : `${hotkey}`;
+
+        // try to use hotkey
+        cy.get('body').type(hotkeyInput);
+        Labels.selectedLabel.contains('Label');
+        // deselect
+        cy.get('body').type('{esc}');
+      }
+    });
+  }
+});

--- a/tests/functional/specs/core/hotkeys.cy.ts
+++ b/tests/functional/specs/core/hotkeys.cy.ts
@@ -1,8 +1,8 @@
-import { Labels, LabelStudio } from '../../../../../../ls-frontend-test/helpers/LSF';
+import { Labels, LabelStudio } from '@heartexlabs/ls-test/helpers/LSF';
 import {
   createConfigWithHotkey
 } from '../../data/core/hotkeys';
-import { Generator } from '../../../../../../ls-frontend-test/helpers/common/Generator';
+import { Generator } from '@heartexlabs/ls-test/helpers/common/Generator';
 
 describe('Hotkeys', () => {
   const hotkeysToCheck = [


### PR DESCRIPTION
This PR 
1. wraps unbinding functional to separate keys corectly outside of the keymaster
2. adds alias for `,` to avoid problems with it
3. improves tokenization of hotkeys

### PR fulfills these requirements
- [x] Tests for the changes have been added/updated
- [ ] Docs have been added/updated
- [x] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance

### Describe the reason for change
Keymaster can't handle unbinding of multiple keys. It also misunderstands `,` and thinks that it is two hotkeys in one (`','` and `''`). So that `,` breaks application in two ways related to each other.

### What alternative approaches were there?
1. we can fix keymaster in a fork (but we did it before and we didn't like it)
2. we can use another library to handle hotkeys. But it's hard to test and integrate.

### This change affects (describe how if yes)
- [ ] Performance
- [ ] Security
- [ ] UX

### Does this PR introduce a breaking change?
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [x] No
- [ ] Not sure (briefly explain the situation below)

### What level of testing was included in the change?
- [ ] e2e (codecept)
- [x] integration (cypress)
- [ ] unit (jest)

### Which logical domain(s) does this change affect?
`Hotkeys`, `Labels`
