### PR TITLE
fix: LEAP-344: View all annotation tab is not loading

### DIFF
--- a/src/components/App/Grid.js
+++ b/src/components/App/Grid.js
@@ -21,6 +21,11 @@ This triggers next rerender with next annotation until all the annotations are r
 class Item extends Component {
   componentDidMount() {
     Promise.all(this.props.annotation.objects.map(o => {
+      // as the image has lazy load, and the image is not being added to the viewport
+      // until it's loaded we need to skip the validation assuming that it's always ready,
+      // otherwise we'll get a blank canvas
+      if (o.type === 'image') return Promise.resolve();
+      
       return o.isReady
         ? Promise.resolve(o.isReady)
         : new Promise(resolve => {


### PR DESCRIPTION
### PR fulfills these requirements
- [x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [x] Frontend



### Describe the reason for change
The "View All Annotations" tab was experiencing loading issues when accessed with a configuration containing an image. The problem stemmed from the validation process, which was impeded by the lazy loading behavior of the image tag. As a result, the image wasn't added to the viewport until fully loaded, causing the tab to fail to load.



#### What does this fix?
To address this issue, the fix involves skipping the validation if the image is marked as ready. This modification acknowledges the lazy load behavior of the image, ensuring that the validation process doesn't impede the loading of the "View All Annotations" tab.



#### What libraries were added/updated?
None



#### Does this change affect performance?
no



#### Does this change affect security?
no



#### What alternative approaches were there?
Consideration was given to removing the lazy load from the ImageView to directly address the loading issues. However, it's crucial to note that this alternative approach comes with potential performance degradation.



#### What feature flags were used to cover this change?
no



### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [x] No
- [ ] Not sure (briefly explain the situation below)



### What level of testing was included in the change?
_(check all that apply)_
- [ ] e2e
- [ ] integration
- [ ] unit



### Which logical domain(s) does this change affect?
`Grid`
