### PR TITLE
fix: LEAP-515: Fix CommentForm for old UI

### DIFF
--- a/src/components/AnnotationTab/AnnotationTab.js
+++ b/src/components/AnnotationTab/AnnotationTab.js
@@ -54,6 +54,7 @@ export const AnnotationTab = observer(({ store }) => {
 
           <Elem name="content">
             <Comments
+              annotationStore={as}
               commentStore={store.commentStore}
               cacheKey={`task.${store.task.id}`}
             />


### PR DESCRIPTION
annotationStore was not passed to Comments panel there

### PR fulfills these requirements
- [ ] Tests for the changes have been added/updated
- [ ] Docs have been added/updated
- [x] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance

### Describe the reason for change
This was breaking the app completely when old interface is enabled (2 FFs are OFF) and comments interface is enabled as well.

### What feature flags were used to cover this change?
This bug happens only if those 2 flags are disabled:
- `ff_front_1170_outliner_030222_short`
- `fflag_feat_front_dev_3873_labeling_ui_improvements_short`

### What alternative approaches were there?
Inject AppStore to Comments.tsx as we usually do, but typescript can't understand this injection, so let's just pass it through.

### This change affects (describe how if yes)
- [ ] Performance
- [ ] Security
- [x] UX — original change was improving Comments UX and this one fixes app crash

### Does this PR introduce a breaking change?
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [x] No
- [ ] Not sure (briefly explain the situation below)

### What level of testing was included in the change?
- [ ] e2e (codecept)
- [ ] integration (cypress)
- [ ] unit (jest)