### PR TITLE
fix: LEAP-246: Replace overlaping MIG hotkeys

### DIFF
--- a/src/core/Hotkey.ts
+++ b/src/core/Hotkey.ts
@@ -5,9 +5,21 @@ import { createElement, Fragment } from 'react';
 import { Tooltip } from '../common/Tooltip/Tooltip';
 import Hint from '../components/Hint/Hint';
 import { Block, Elem } from '../utils/bem';
-import { FF_LSDV_1148, isFF } from '../utils/feature-flags';
+import { FF_LSDV_1148, FF_MULTI_OBJECT_HOTKEYS, isFF } from '../utils/feature-flags';
 import { isDefined, isMacOS } from '../utils/utilities';
 import defaultKeymap from './settings/keymap.json';
+
+if (!isFF(FF_MULTI_OBJECT_HOTKEYS)) {
+  const prev = (defaultKeymap as Keymap)['image:prev'];
+  const next = (defaultKeymap as Keymap)['image:next'];
+
+  if (prev) {
+    prev.key = prev.mac = 'ctrl+a';
+  }
+  if (next) {
+    next.key = next.mac = 'ctrl+d';
+  }
+}
 
 // Validate keymap integrity
 const allowedKeympaKeys = ['key', 'mac', 'description', 'modifier', 'modifierDescription'];

--- a/src/core/settings/keymap.json
+++ b/src/core/settings/keymap.json
@@ -168,11 +168,13 @@
     "description": "Previous Page"
   },
   "image:prev": {
-    "key": "ctrl+a",
+    "key": "ctrl+left",
+    "mac": "command+left",
     "description": "Previous Image"
   },
   "image:next": {
-    "key": "ctrl+d",
+    "key": "ctrl+right",
+    "mac": "command+right",
     "description": "Next Image"
   }
 }

--- a/src/utils/feature-flags.ts
+++ b/src/utils/feature-flags.ts
@@ -333,6 +333,8 @@ export const FF_ZOOM_OPTIM = 'fflag_fix_front_leap_32_zoom_perf_190923_short';
 
 export const FF_SAFE_TEXT = 'fflag_fix_leap_466_text_sanitization';
 
+export const FF_MULTI_OBJECT_HOTKEYS = 'fflag_fix_leap_246_multi_object_hotkeys_160124_short';
+
 Object.assign(window, {
   APP_SETTINGS: {
     ...(window.APP_SETTINGS ?? {}),


### PR DESCRIPTION
We had the same hotkeys:
1. for the going to next/prev pages in multi-item mode in object tags.
2. for duplicating selected regions

Sometimes it provided unexpected results. So we had to change the hotkeys for going through pages.

### PR fulfills these requirements
- [ ] Tests for the changes have been added/updated
- [ ] Docs have been added/updated
- [ ] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance

### What feature flags were used to cover this change?
`fflag_fix_leap_246_multi_object_hotkeys_160124_short`

### This change affects (describe how if yes)
- [ ] Performance
- [ ] Security
- [ ] UX

### Does this PR introduce a breaking change?
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [x] No
- [ ] Not sure (briefly explain the situation below)

### What level of testing was included in the change?
- [ ] e2e (codecept)
- [ ] integration (cypress)
- [ ] unit (jest)

### Which logical domain(s) does this change affect?
`Hotkeys`