### PR TITLE
fix: LEAP-523: Return region's text to item in a list 

### DIFF
--- a/e2e/tests/ner-text.test.js
+++ b/e2e/tests/ner-text.test.js
@@ -260,8 +260,7 @@ Scenario('NER Text with SECURE MODE', async function({ I, LabelStudio }) {
   });
 });
 
-// eslint-disable-next-line codeceptjs/no-exclusive-tests
-Scenario.only('NER Text regions in Outliner', async function({ I, LabelStudio }) {
+Scenario('NER Text regions in Outliner', async function({ I, LabelStudio }) {
   const params = {
     annotations: [{ id: 'TestCmpl', result: resultsFromUrl }],
     config: configUrl,

--- a/e2e/tests/ner-text.test.js
+++ b/e2e/tests/ner-text.test.js
@@ -259,3 +259,27 @@ Scenario('NER Text with SECURE MODE', async function({ I, LabelStudio }) {
     window.LS_SECURE_MODE = window.OLD_LS_SECURE_MODE;
   });
 });
+
+// eslint-disable-next-line codeceptjs/no-exclusive-tests
+Scenario.only('NER Text regions in Outliner', async function({ I, LabelStudio }) {
+  const params = {
+    annotations: [{ id: 'TestCmpl', result: resultsFromUrl }],
+    config: configUrl,
+    data: { url },
+  };
+
+  I.amOnPage('/');
+  // enabling both flags for New UI, but will work with Otliner one only as well
+  LabelStudio.setFeatureFlags({
+    ff_front_1170_outliner_030222_short: true,
+    fflag_feat_front_dev_3873_labeling_ui_improvements_short: true,
+  });
+  LabelStudio.init(params);
+
+  I.waitForElement('.lsf-richtext__line', 60);
+
+  I.see('American political leader');
+
+  I.seeElement(locate('.lsf-outliner-item').withText(resultsFromUrl[0].value.text));
+  I.seeElement(locate('.lsf-outliner-item').withText(resultsFromUrl[1].value.text));
+});

--- a/src/components/Node/Node.tsx
+++ b/src/components/Node/Node.tsx
@@ -127,7 +127,7 @@ const NodeDebug: FC<any> = observer(({ className, node }) => {
 const Node: FC<any> = observer(({ className, node }) => {
   const name = useNodeName(node);
 
-  if (!(name in NodeViews)) {
+  if (!name || !(name in NodeViews)) {
     console.error(`No ${name} in NodeView`);
     return null;
   }
@@ -138,9 +138,9 @@ const Node: FC<any> = observer(({ className, node }) => {
   return (
     <Block name="node" tag="span" className={className}>
       {labelName}
-      {node?.isDrawing && (
+      {node.isDrawing && (
         <Elem tag="span" name="incomplete">
-          <Tooltip title="Incomplete polygon">
+          <Tooltip title={`Incomplete ${node.type?.replace('region', '') ?? 'region'}`}>
             <IconWarning />
           </Tooltip>
         </Elem>

--- a/src/components/SidePanels/DetailsPanel/RegionDetails.tsx
+++ b/src/components/SidePanels/DetailsPanel/RegionDetails.tsx
@@ -91,13 +91,9 @@ export const RegionDetailsMain: FC<{region: any}> = observer(({
         {region?.text ? (
           <Block name="region-meta">
             <Elem name="item">
-              <Elem
-                name="content"
-                mod={{ type: 'text' }}
-                dangerouslySetInnerHTML={{
-                  __html: region.text.replace(/\\n/g, '\n'),
-                }}
-              />
+              <Elem name="content" mod={{ type: 'text' }}>
+                {region.text.replace(/\\n/g, '\n')}
+              </Elem>
             </Elem>
           </Block>
         ) : null}

--- a/src/components/SidePanels/DetailsPanel/RegionItem.tsx
+++ b/src/components/SidePanels/DetailsPanel/RegionItem.tsx
@@ -50,10 +50,10 @@ export const RegionItem: FC<RegionItemProps> = observer(({
         {withIds && <span>{region.cleanId}</span>}
       </Elem>
       {MainDetails && <Elem name="content"><MainDetails region={region}/></Elem>}
-      {region?.isDrawing && (
+      {region.isDrawing && (
         <Elem name="warning">
           <IconWarning />
-          <Elem name="warning-text">Incomplete {region.type.replace('region', '')}</Elem>
+          <Elem name="warning-text">Incomplete {region.type?.replace('region', '') ?? 'region'}</Elem>
         </Elem>
       )}
       {withActions && (

--- a/src/components/SidePanels/OutlinerPanel/OutlinerTree.tsx
+++ b/src/components/SidePanels/OutlinerPanel/OutlinerTree.tsx
@@ -440,7 +440,7 @@ const RootTitle: FC<any> = observer(({
           {item.text && <Elem name="text">{item.text.replace(/\\n/g, '\n')}</Elem>}
           {item?.isDrawing && (
             <Elem tag="span" name="incomplete">
-              <Tooltip title="Incomplete polygon">
+              <Tooltip title={`Incomplete ${item.type?.replace('region', '') ?? 'region'}$`}>
                 <IconWarning />
               </Tooltip>
             </Elem>

--- a/src/components/SidePanels/OutlinerPanel/OutlinerTree.tsx
+++ b/src/components/SidePanels/OutlinerPanel/OutlinerTree.tsx
@@ -408,7 +408,7 @@ const NodeIconComponent: FC<any> = observer(({ node }) => {
 });
 
 const RootTitle: FC<any> = observer(({
-  item,
+  item, // can be undefined for group titles in Labels or Tools mode
   label,
   isArea,
   ...props
@@ -437,7 +437,7 @@ const RootTitle: FC<any> = observer(({
         {!props.isGroup && <Elem name="index">{props.idx + 1}</Elem>}
         <Elem name="title">
           {label}
-          {item.text && <Elem name="text">{item.text.replace(/\\n/g, '\n')}</Elem>}
+          {item?.text && <Elem name="text">{item.text.replace(/\\n/g, '\n')}</Elem>}
           {item?.isDrawing && (
             <Elem tag="span" name="incomplete">
               <Tooltip title={`Incomplete ${item.type?.replace('region', '') ?? 'region'}$`}>

--- a/src/components/SidePanels/OutlinerPanel/OutlinerTree.tsx
+++ b/src/components/SidePanels/OutlinerPanel/OutlinerTree.tsx
@@ -440,7 +440,7 @@ const RootTitle: FC<any> = observer(({
           {item?.text && <Elem name="text">{item.text.replace(/\\n/g, '\n')}</Elem>}
           {item?.isDrawing && (
             <Elem tag="span" name="incomplete">
-              <Tooltip title={`Incomplete ${item.type?.replace('region', '') ?? 'region'}$`}>
+              <Tooltip title={`Incomplete ${item.type?.replace('region', '') ?? 'region'}`}>
                 <IconWarning />
               </Tooltip>
             </Elem>

--- a/src/components/SidePanels/OutlinerPanel/OutlinerTree.tsx
+++ b/src/components/SidePanels/OutlinerPanel/OutlinerTree.tsx
@@ -437,6 +437,7 @@ const RootTitle: FC<any> = observer(({
         {!props.isGroup && <Elem name="index">{props.idx + 1}</Elem>}
         <Elem name="title">
           {label}
+          {item.text && <Elem name="text">{item.text.replace(/\\n/g, '\n')}</Elem>}
           {item?.isDrawing && (
             <Elem tag="span" name="incomplete">
               <Tooltip title="Incomplete polygon">

--- a/src/components/SidePanels/OutlinerPanel/TreeView.styl
+++ b/src/components/SidePanels/OutlinerPanel/TreeView.styl
@@ -75,6 +75,7 @@
   &-title
     flex 1
     padding-left 5px
+    min-width 0
 
     .labels-list
       display inline-block
@@ -117,6 +118,14 @@
     display inline-flex
     flex 1
     color var(--text-color, #000)
+    min-width 0
+
+  &__text
+    margin-left 5px
+    color #000
+    overflow hidden
+    white-space nowrap
+    text-overflow ellipsis
 
   &__incomplete
     display inline-flex


### PR DESCRIPTION
New Outliner dropped this important info from region items in the list.
Returning it back.

### PR fulfills these requirements
- [x] Tests for the changes have been added/updated
- [ ] Docs have been added/updated
- [x] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance

### Describe the reason for change
We need to remove flags for Outliner and NEW UI, enabling it for everyone. To do this smoothly new UI should be very similar to old ones, and that's one of the most important differences.

### What feature flags were used to cover this change?
Outliner `ff_front_1170_outliner_030222_short`
New UI `fflag_feat_front_dev_3873_labeling_ui_improvements_short`

### This change affects (describe how if yes)
- [ ] Performance
- [x] Security — a little, onn of `dangerouslySetInnerHTML` removed
- [x] UX — region text is always visible in the list for all items

### Does this PR introduce a breaking change?
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [x] No
- [ ] Not sure (briefly explain the situation below)

### What level of testing was included in the change?
- [x] e2e (codecept)
- [ ] integration (cypress)
- [ ] unit (jest)