### PR TITLE
Fix: LEAP-580: Display non-string values in Text

### DIFF
--- a/src/tags/object/RichText/model.js
+++ b/src/tags/object/RichText/model.js
@@ -222,7 +222,7 @@ const Model = types
         // nodes count better be the same, so replace them with stubs
         // we should not sanitize text tasks because we already have htmlEscape in view.js
         if (isFF(FF_SAFE_TEXT) && self.type === 'text') {
-          self._value = val;
+          self._value = String(val);
         } else {
           self._value = sanitizeHtml(String(val));
         }


### PR DESCRIPTION
During recent incident fix we missed conversion to string for Text tag's `value` param.

Tests are coming!

### PR fulfills these requirements
- [ ] Tests for the changes have been added/updated
- [ ] Docs have been added/updated
- [ ] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [ ] Self-reviewed and ran all changes on a local instance

### Describe the reason for change
(if it's not clear from description)

### What feature flags were used to cover this change?

### What alternative approaches were there?

### This change affects (describe how if yes)
- [ ] Performance
- [ ] Security
- [ ] UX

### Does this PR introduce a breaking change?
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [ ] No
- [ ] Not sure (briefly explain the situation below)

### What level of testing was included in the change?
- [ ] e2e (codecept)
- [ ] integration (cypress)
- [ ] unit (jest)