### PR TITLE
fix: LEAP-580: Display non-string values in Text

### DIFF
--- a/src/tags/object/RichText/model.js
+++ b/src/tags/object/RichText/model.js
@@ -222,7 +222,7 @@ const Model = types
         // nodes count better be the same, so replace them with stubs
         // we should not sanitize text tasks because we already have htmlEscape in view.js
         if (isFF(FF_SAFE_TEXT) && self.type === 'text') {
-          self._value = val;
+          self._value = String(val);
         } else {
           self._value = sanitizeHtml(String(val));
         }

--- a/src/utils/data.js
+++ b/src/utils/data.js
@@ -16,10 +16,10 @@ export const parseValue = (value, task) => {
 
   // value can refer to structures, not only texts, so just replace wouldn't be enough
   if (value.match(reVar)?.[0] === value) {
-    return get(task, value.substr(1)) ?? '';
+    return get(task, value.slice(1)) ?? '';
   }
 
-  return value.replace(reVar, (v) => get(task, v.substr(1) ?? ''));
+  return value.replace(reVar, (v) => get(task, v.slice(1) ?? ''));
 };
 
 /**

--- a/tests/functional/specs/object_tags/text.cy.ts
+++ b/tests/functional/specs/object_tags/text.cy.ts
@@ -1,0 +1,37 @@
+import { LabelStudio } from '@heartexlabs/ls-test/helpers/LSF';
+
+describe('<Text> tag', () => {
+  it('Display non-string values', () => {
+    const config = `
+      <View>
+        <Header>String — usual case</Header>
+        <Text name="string" value="$string"></Text>
+        <Header>Float number</Header>
+        <Text name="number" value="$number"></Text>
+        <Header>Boolean</Header>
+        <Text name="bool" value="$bool"></Text>
+        <Header>Array</Header>
+        <Text name="array" value="$array"></Text>
+        <Header value="Crazy header $string $number $bool $array" />
+      </View>
+    `;
+
+    const data = {
+      string: 'Simple text',
+      number: 123.45,
+      bool: false,
+      array: [1, 2, 3],
+    };
+
+    LabelStudio.params()
+      .config(config)
+      .data(data)
+      .withResult([])
+      .init();
+
+    cy.get('.lsf-object').contains('Simple text').should('be.visible');
+    cy.get('.lsf-object').contains('123.45').should('be.visible');
+    cy.get('.lsf-object').contains('false').should('be.visible');
+    cy.get('.lsf-object').contains('1,2,3').should('be.visible');
+  });
+});


### PR DESCRIPTION
Cherry-pick of #1675

* Fix: LEAP-580: Display non-string values in Text

During recent incident fix we missed conversion to string for Text tag's `value` param.

* Fix deprecated `substr` to `slice` in `parseValue`

* Add cypress test for non-string values
