### PR TITLE
docs: LEAP-615: Mention spaces saving for Text tag

### DIFF
--- a/src/tags/object/Text.js
+++ b/src/tags/object/Text.js
@@ -2,7 +2,7 @@
 
 /**
  * The `Text` tag shows text that can be labeled. Use to display any type of text on the labeling interface.
- * You can use `<Style>.htx-text{ white-space: pre-wrap; }</Style>` to preserve all spaces in the text, otherwise spaces are trimmed when displayed and saved to result.
+ * You can use `<Style>.htx-text{ white-space: pre-wrap; }</Style>` to preserve all spaces in the text, otherwise spaces are trimmed when displayed and saved in the results. 
  * Every space in the text sample is counted when calculating result offsets, for example for NER labeling tasks.
  *
  * Use with the following data types: text.

--- a/src/tags/object/Text.js
+++ b/src/tags/object/Text.js
@@ -2,7 +2,7 @@
 
 /**
  * The `Text` tag shows text that can be labeled. Use to display any type of text on the labeling interface.
- * You can use `<Style>.htx-text{ white-space: pre-wrap; }</Style>` to preserve all spaces in the text, otherwise spaces are trimmed when displayed.
+ * You can use `<Style>.htx-text{ white-space: pre-wrap; }</Style>` to preserve all spaces in the text, otherwise spaces are trimmed when displayed and saved to result.
  * Every space in the text sample is counted when calculating result offsets, for example for NER labeling tasks.
  *
  * Use with the following data types: text.


### PR DESCRIPTION
Text tag is displayed as html, so all spaces are smashed by browser, and they also go like this to result. To avoid this users can add custom style in config, described in docs. But it only says that this affects displaying, not saving the result. Adding this note as well.

### PR fulfills these requirements
- [ ] Tests for the changes have been added/updated
- [x] Docs have been added/updated
- [x] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [ ] Self-reviewed and ran all changes on a local instance

### Describe the reason for change
https://github.com/HumanSignal/label-studio/issues/5338
