### PR TITLE
fix: LEAP-148: Fix MagicWand in MIG scenario with image preloading

### DIFF
--- a/src/components/ImageView/Image.js
+++ b/src/components/ImageView/Image.js
@@ -30,6 +30,7 @@ export const Image = observer(forwardRef(({
   updateImageSize,
   usedValue,
   size,
+  overlay,
 }, ref) => {
   const imageSize = useMemo(() => {
     return {
@@ -45,6 +46,7 @@ export const Image = observer(forwardRef(({
 
   return (
     <Block name="image" style={imageSize}>
+      {overlay}
       <ImageProgress
         downloading={imageEntity.downloading}
         progress={imageEntity.progress}
@@ -76,7 +78,7 @@ const ImageProgress = observer(({
   return downloading ? (
     <Block name="image-progress">
       <Elem name="message">Downloading image</Elem>
-      <Elem tag="progress" name="bar" value={progress} min="0" max={1} step={0.0001}/>
+      <Elem tag="progress" name="bar" value={progress} min="0" max={1} step={0.0001} />
     </Block>
   ) : error ? (
     <ImageLoadingError src={src} value={usedValue} />
@@ -121,6 +123,6 @@ const ImageLoadingError = ({ src, value }) => {
   }, [src]);
 
   return (
-    <ErrorMessage error={error}/>
+    <ErrorMessage error={error} />
   );
 };

--- a/src/components/ImageView/ImageView.js
+++ b/src/components/ImageView/ImageView.js
@@ -490,6 +490,22 @@ const Crosshair = memo(forwardRef(({ width, height }, ref) => {
   );
 }));
 
+/**
+ * Component that creates an overlay on top
+ * of the image to support Magic Wand tool
+ */
+const CanvasOverlay = observer(({ item }) => {
+  return isFF(FF_DEV_4081) ? (
+    <canvas
+      className={styles.overlay}
+      ref={ref => {
+        item.setOverlayRef(ref);
+      }}
+      style={item.imageTransform}
+    />
+  ) : null;
+});
+
 export default observer(
   class ImageView extends Component {
     // stored position of canvas before creating region
@@ -1001,6 +1017,7 @@ export default observer(
                 imageTransform={item.imageTransform}
                 updateImageSize={item.updateImageSize}
                 size={item.canvasSize}
+                overlay={<CanvasOverlay item={item} />}
               />
             ) : (
               <div
@@ -1026,15 +1043,7 @@ export default observer(
                   crossOrigin={item.imageCrossOrigin}
                   alt="LS"
                 />
-                {isFF(FF_DEV_4081) ? (
-                  <canvas
-                    className={styles.overlay}
-                    ref={ref => {
-                      item.setOverlayRef(ref);
-                    }}
-                    style={item.imageTransform}
-                  />
-                ) : null}
+                <CanvasOverlay item={item} />
               </div>
             )}
             {/* @todo this is dirty hack; rewrite to proper async waiting for data to load */}

--- a/src/tools/MagicWand.js
+++ b/src/tools/MagicWand.js
@@ -252,7 +252,7 @@ const _Tool = types
           msg = 'The Magic Wand is not supported on rotated images';
         } else {
           msg = 'The Magic Wand is not supported if the crosshair is turned on';
-        } 
+        }
 
         alert(msg);
         throw msg;

--- a/tests/functional/package.json
+++ b/tests/functional/package.json
@@ -20,7 +20,7 @@
     "cvg:summary": "nyc report --temp-dir=.nyc_output --reporter=text-summary --cwd=. --exclude-after-remap false"
   },
   "dependencies": {
-    "@heartexlabs/ls-test": "heartexlabs/ls-frontend-test#9ff949fc19abaf124477dfd41c6f230b00665ab3"
+    "@heartexlabs/ls-test": "heartexlabs/ls-frontend-test#2c9410fb930c7d920474fe6e624efee6261cec0c"
   },
   "devDependencies": {
     "ts-loader": "^9.4.2",

--- a/tests/functional/specs/relations/basic.cy.ts
+++ b/tests/functional/specs/relations/basic.cy.ts
@@ -1,10 +1,13 @@
-import { ImageView, LabelStudio, Relations, ToolBar } from '@heartexlabs/ls-test/helpers/LSF';
+import { Hotkeys, ImageView, LabelStudio, Relations, ToolBar } from '@heartexlabs/ls-test/helpers/LSF';
 import {
   imageConfigWithRelations,
   simpleImageConfig,
-  simpleImageData, simpleImageResult,
+  simpleImageData,
+  simpleImageResult,
   simpleImageResultWithRelation,
-  simpleImageResultWithRelations, simpleImageResultWithRelationsAndLabels, simpleImageResultWithRelationsAndLabelsAlt
+  simpleImageResultWithRelations,
+  simpleImageResultWithRelationsAndLabels,
+  simpleImageResultWithRelationsAndLabelsAlt
 } from '../../data/relations/basic';
 
 describe('Relations: Basic', () => {
@@ -176,19 +179,19 @@ describe('Relations: Basic', () => {
 
     Relations.hasRelations(0);
 
-    ImageView.clickAtRelative(.30, .30);
+    ImageView.clickAtRelative(0.3, 0.3);
     Relations.toggleCreationWithHotkey();
-    ImageView.clickAtRelative(.60, .60);
+    ImageView.clickAtRelative(0.6, 0.6);
 
-    cy.window().then((win) => {
+    cy.window().then(win => {
       expect(win.Htx.annotationStore.selected.history.history.length).to.equal(2);
     });
 
-    cy.get('body').type('{ctrl+z}');
+    Hotkeys.undo();
     Relations.hasRelations(0);
-    cy.get('body').type('{ctrl+shift+z}');
+    Hotkeys.redo();
     Relations.hasRelations(1);
-    cy.window().then((win) => {
+    cy.window().then(win => {
       expect(win.Htx.annotationStore.selected.history.history.length).to.equal(2);
     });
   });
@@ -203,26 +206,26 @@ describe('Relations: Basic', () => {
     ImageView.waitForImage();
 
     Relations.hasRelations(1);
-    cy.window().then((win) => {
+    cy.window().then(win => {
       expect(win.Htx.annotationStore.selected.history.history.length).to.equal(1);
     });
 
     Relations.deleteRelationAction(0);
 
     Relations.hasRelations(0);
-    cy.window().then((win) => {
+    cy.window().then(win => {
       expect(win.Htx.annotationStore.selected.history.history.length).to.equal(2);
     });
 
-    cy.get('body').type('{ctrl+z}');
+    Hotkeys.undo();
     Relations.hasRelations(1);
-    cy.window().then((win) => {
+    cy.window().then(win => {
       expect(win.Htx.annotationStore.selected.history.history.length).to.equal(2);
     });
 
-    cy.get('body').type('{ctrl+shift+z}');
+    Hotkeys.redo();
     Relations.hasRelations(0);
-    cy.window().then((win) => {
+    cy.window().then(win => {
       expect(win.Htx.annotationStore.selected.history.history.length).to.equal(2);
     });
   });
@@ -237,14 +240,14 @@ describe('Relations: Basic', () => {
     ImageView.waitForImage();
 
     Relations.hasRelations(1);
-    cy.window().then((win) => {
+    cy.window().then(win => {
       expect(win.Htx.annotationStore.selected.history.history.length).to.equal(1);
     });
 
     Relations.toggleRelationDirection(0);
 
     Relations.hasRelations(1);
-    cy.window().then((win) => {
+    cy.window().then(win => {
       expect(win.Htx.annotationStore.selected.history.history.length).to.equal(2);
     });
   });
@@ -263,19 +266,19 @@ describe('Relations: Basic', () => {
     Relations.clickShowRelationLabels(0);
     Relations.addLabelToRelation('Blue label', 0);
     Relations.hasRelationLabels(['Blue label'], 0);
-    cy.window().then((win) => {
+    cy.window().then(win => {
       expect(win.Htx.annotationStore.selected.history.history.length).to.equal(2);
     });
 
-    cy.get('body').type('{ctrl+z}');
+    Hotkeys.undo();
     Relations.hasRelationLabels([], 0);
-    cy.window().then((win) => {
+    cy.window().then(win => {
       expect(win.Htx.annotationStore.selected.history.history.length).to.equal(2);
     });
 
-    cy.get('body').type('{ctrl+shift+z}');
+    Hotkeys.redo();
     Relations.hasRelationLabels(['Blue label'], 0);
-    cy.window().then((win) => {
+    cy.window().then(win => {
       expect(win.Htx.annotationStore.selected.history.history.length).to.equal(2);
     });
   });
@@ -292,7 +295,7 @@ describe('Relations: Basic', () => {
     Relations.hoverOverRelation(0);
     Relations.stopHoveringOverRelation(0);
 
-    cy.window().then((win) => {
+    cy.window().then(win => {
       expect(win.Htx.annotationStore.selected.history.history.length).to.equal(1);
     });
   });
@@ -307,12 +310,12 @@ describe('Relations: Basic', () => {
     ImageView.waitForImage();
 
     Relations.hasRelations(1);
-    cy.window().then((win) => {
+    cy.window().then(win => {
       expect(win.Htx.annotationStore.selected.history.history.length).to.equal(1);
     });
 
     Relations.hideRelationAction(0);
-    cy.window().then((win) => {
+    cy.window().then(win => {
       expect(win.Htx.annotationStore.selected.history.history.length).to.equal(1);
     });
   });

--- a/tests/functional/yarn.lock
+++ b/tests/functional/yarn.lock
@@ -264,9 +264,9 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
 
-"@heartexlabs/ls-test@heartexlabs/ls-frontend-test#9ff949fc19abaf124477dfd41c6f230b00665ab3":
+"@heartexlabs/ls-test@heartexlabs/ls-frontend-test#2c9410fb930c7d920474fe6e624efee6261cec0c":
   version "1.0.8"
-  resolved "https://codeload.github.com/heartexlabs/ls-frontend-test/tar.gz/9ff949fc19abaf124477dfd41c6f230b00665ab3"
+  resolved "https://codeload.github.com/heartexlabs/ls-frontend-test/tar.gz/2c9410fb930c7d920474fe6e624efee6261cec0c"
   dependencies:
     "@cypress/code-coverage" "^3.10.0"
     "@cypress/webpack-preprocessor" "^5.17.0"
@@ -277,30 +277,7 @@
     cypress-parallel "^0.12.0"
     cypress-plugin-snapshots "^1.4.4"
     cypress-terminal-report "^5.1.1"
-    pixelmatch "^5.3.0"
-    pngjs "^7.0.0"
-    proper-lockfile "^4.1.2"
-    sinon "^16.1.0"
-    sinon-chai "^3.7.0"
-    ts-loader "^9.4.2"
-    typescript "^4.9.5"
-    webpack "^5.77.0"
-    webpack-cli "^5.0.1"
-    yargs "^17.7.1"
-
-"@heartexlabs/ls-test@heartexlabs/ls-frontend-test#df8e7ea65179f5d143a4a299428116646f2236c4":
-  version "1.0.8"
-  resolved "https://codeload.github.com/heartexlabs/ls-frontend-test/tar.gz/df8e7ea65179f5d143a4a299428116646f2236c4"
-  dependencies:
-    "@cypress/code-coverage" "^3.10.0"
-    "@cypress/webpack-preprocessor" "^5.17.0"
-    chai "^4.3.7"
-    cypress "12.17.4"
-    cypress-image-snapshot "^4.0.1"
-    cypress-multi-reporters "^1.6.2"
-    cypress-parallel "^0.12.0"
-    cypress-plugin-snapshots "^1.4.4"
-    cypress-terminal-report "^5.1.1"
+    del "^7.1.0"
     pixelmatch "^5.3.0"
     pngjs "^7.0.0"
     proper-lockfile "^4.1.2"
@@ -1002,6 +979,14 @@ aggregate-error@^3.0.0:
     clean-stack "^2.0.0"
     indent-string "^4.0.0"
 
+aggregate-error@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/aggregate-error/-/aggregate-error-4.0.1.tgz#25091fe1573b9e0be892aeda15c7c66a545f758e"
+  integrity sha512-0poP0T7el6Vq3rstR8Mn4V/IQrpBLO6POkUSrN7RhyY+GF/InCFShQzsQ39T25gkHhLgSLByyAz+Kjb+c2L98w==
+  dependencies:
+    clean-stack "^4.0.0"
+    indent-string "^5.0.0"
+
 ajv-keywords@^3.5.2:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.5.2.tgz#31f29da5ab6e00d1c2d329acf7b5929614d5014d"
@@ -1408,6 +1393,13 @@ clean-stack@^2.0.0:
   resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-2.2.0.tgz#ee8472dbb129e727b31e8a10a427dee9dfe4008b"
   integrity sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==
 
+clean-stack@^4.0.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-4.2.0.tgz#c464e4cde4ac789f4e0735c5d75beb49d7b30b31"
+  integrity sha512-LYv6XPxoyODi36Dp976riBtSY27VmFo+MKqEU9QCCWyTrdEPDog+RWA7xQWHi6Vbp61j5c4cdzzX1NidnwtUWg==
+  dependencies:
+    escape-string-regexp "5.0.0"
+
 cli-cursor@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-3.1.0.tgz#264305a7ae490d1d03bf0c9ba7c925d1753af307"
@@ -1762,6 +1754,20 @@ default-require-extensions@^3.0.0:
   dependencies:
     strip-bom "^4.0.0"
 
+del@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/del/-/del-7.1.0.tgz#0de0044d556b649ff05387f1fa7c885e155fd1b6"
+  integrity sha512-v2KyNk7efxhlyHpjEvfyxaAihKKK0nWCuf6ZtqZcFFpQRG0bJ12Qsr0RpvsICMjAAZ8DOVCxrlqpxISlMHC4Kg==
+  dependencies:
+    globby "^13.1.2"
+    graceful-fs "^4.2.10"
+    is-glob "^4.0.3"
+    is-path-cwd "^3.0.0"
+    is-path-inside "^4.0.0"
+    p-map "^5.5.0"
+    rimraf "^3.0.2"
+    slash "^4.0.0"
+
 delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
@@ -1914,6 +1920,11 @@ escape-string-regexp@4.0.0:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
+escape-string-regexp@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz#4683126b500b61762f2dbebace1806e8be31b1c8"
+  integrity sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==
+
 escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
@@ -2034,6 +2045,17 @@ fast-glob@^3.1.1:
   version "3.2.12"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.12.tgz#7f39ec99c2e6ab030337142da9e0c18f37afae80"
   integrity sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.2"
+    merge2 "^1.3.0"
+    micromatch "^4.0.4"
+
+fast-glob@^3.3.0:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.2.tgz#a904501e57cfdd2ffcded45e99a54fef55e46129"
+  integrity sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==
   dependencies:
     "@nodelib/fs.stat" "^2.0.2"
     "@nodelib/fs.walk" "^1.2.3"
@@ -2326,12 +2348,23 @@ globby@11.0.4:
     merge2 "^1.3.0"
     slash "^3.0.0"
 
+globby@^13.1.2:
+  version "13.2.2"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-13.2.2.tgz#63b90b1bf68619c2135475cbd4e71e66aa090592"
+  integrity sha512-Y1zNGV+pzQdh7H39l9zgB4PJqjRNqydvdYCDG4HFXM4XuvSaQQlEc91IU1yALL8gUTDomgBAfz3XJdmUS+oo0w==
+  dependencies:
+    dir-glob "^3.0.1"
+    fast-glob "^3.3.0"
+    ignore "^5.2.4"
+    merge2 "^1.4.1"
+    slash "^4.0.0"
+
 glur@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/glur/-/glur-1.1.2.tgz#f20ea36db103bfc292343921f1f91e83c3467689"
   integrity sha512-l+8esYHTKOx2G/Aao4lEQ0bnHWg4fWtJbVoZZT9Knxi01pB8C80BR85nONLFwkkQoFRCmXY+BUcGZN3yZ2QsRA==
 
-graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.4, graceful-fs@^4.2.9:
+graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.10, graceful-fs@^4.2.4, graceful-fs@^4.2.9:
   version "4.2.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
@@ -2432,6 +2465,11 @@ ignore@^5.1.4:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.4.tgz#a291c0c6178ff1b960befe47fcdec301674a6324"
   integrity sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==
 
+ignore@^5.2.4:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.0.tgz#67418ae40d34d6999c95ff56016759c718c82f78"
+  integrity sha512-g7dmpshy+gD7mh88OC9NwSGTKoc3kyLAZQRU1mt53Aw/vnvfXnbC+F/7F7QoYVKbV+KNvJx8wArewKy1vXMtlg==
+
 image-size@^0.7.2:
   version "0.7.5"
   resolved "https://registry.yarnpkg.com/image-size/-/image-size-0.7.5.tgz#269f357cf5797cb44683dfa99790e54c705ead04"
@@ -2454,6 +2492,11 @@ indent-string@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-4.0.0.tgz#624f8f4497d619b2d9768531d58f4122854d7251"
   integrity sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==
+
+indent-string@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-5.0.0.tgz#4fd2980fccaf8622d14c64d694f4cf33c81951a5"
+  integrity sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==
 
 indexof@0.0.1:
   version "0.0.1"
@@ -2519,7 +2562,7 @@ is-function@^1.0.1:
   resolved "https://registry.yarnpkg.com/is-function/-/is-function-1.0.2.tgz#4f097f30abf6efadac9833b17ca5dc03f8144e08"
   integrity sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ==
 
-is-glob@^4.0.1, is-glob@~4.0.1:
+is-glob@^4.0.1, is-glob@^4.0.3, is-glob@~4.0.1:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.3.tgz#64f61e42cbbb2eec2071a9dac0b28ba1e65d5084"
   integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
@@ -2544,10 +2587,20 @@ is-number@^7.0.0:
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
+is-path-cwd@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-path-cwd/-/is-path-cwd-3.0.0.tgz#889b41e55c8588b1eb2a96a61d05740a674521c7"
+  integrity sha512-kyiNFFLU0Ampr6SDZitD/DwUo4Zs1nSdnygUBqsu3LooL00Qvb5j+UnvApUn/TTj1J3OuE6BTdQ5rudKmU2ZaA==
+
 is-path-inside@^3.0.2:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-3.0.3.tgz#d231362e53a07ff2b0e0ea7fed049161ffd16283"
   integrity sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==
+
+is-path-inside@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-4.0.0.tgz#805aeb62c47c1b12fc3fd13bfb3ed1e7430071db"
+  integrity sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==
 
 is-plain-obj@^2.1.0:
   version "2.1.0"
@@ -2957,7 +3010,7 @@ merge-stream@^2.0.0:
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
   integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
 
-merge2@^1.3.0:
+merge2@^1.3.0, merge2@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
@@ -3259,6 +3312,13 @@ p-map@^4.0.0:
   integrity sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==
   dependencies:
     aggregate-error "^3.0.0"
+
+p-map@^5.5.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/p-map/-/p-map-5.5.0.tgz#054ca8ca778dfa4cf3f8db6638ccb5b937266715"
+  integrity sha512-VFqfGDHlx87K66yZrNdI4YGtD70IRyd+zSvgks6mzHPRNkoKy+9EKP4SFC77/vTTQYmRmti7dvqC+m5jBrBAcg==
+  dependencies:
+    aggregate-error "^4.0.0"
 
 p-try@^2.0.0:
   version "2.2.0"
@@ -3619,7 +3679,7 @@ rimraf@^2.6.2, rimraf@^2.6.3:
   dependencies:
     glob "^7.1.3"
 
-rimraf@^3.0.0:
+rimraf@^3.0.0, rimraf@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
@@ -3780,6 +3840,11 @@ slash@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
+
+slash@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/slash/-/slash-4.0.0.tgz#2422372176c4c6c5addb5e2ada885af984b396a7"
+  integrity sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==
 
 slice-ansi@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
When both MIG and image preloading are enabled, there was no canvas overlay for the Magic Wand which caused the Magic Wand to fail.

### PR fulfills these requirements
- [x] Tests for the changes have been added/updated
- [ ] Docs have been added/updated
- [x] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance

### What feature flags were used to cover this change?
Not really covered but affected by:
`fflag_feat_front_lsdv_4583_6_images_preloading_short`
`fflag_feat_front_dev_4081_magic_wand_tool`

### What alternative approaches were there?
https://github.com/HumanSignal/label-studio-frontend/pull/1327
But we believe that it's not neccesary since the way Magic Wand works [was fixed recently](https://github.com/HumanSignal/label-studio/pull/5246) and potentially we don't need async stuff.

### This change affects (describe how if yes)
- [ ] Performance
- [ ] Security
- [ ] UX

### Does this PR introduce a breaking change?
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [x] No
- [ ] Not sure (briefly explain the situation below)

### What level of testing was included in the change?
- [ ] e2e (codecept)
- [ ] integration (cypress)
- [ ] unit (jest)

### Which logical domain(s) does this change affect?
`Multy Image Segmentation`, `Magic Wand`
