### PR TITLE
fix: OPTIC-411: [lsp] Fix Follow Redirects improperly handles URLs in the url.parse() function

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -48,6 +48,7 @@
   },
   "resolutions": {
     "debug": "^4.3.1",
-    "electron": "^22.3.25"
+    "electron": "^22.3.25",
+    "follow-redirects": "1.15.4"
   }
 }

--- a/e2e/yarn.lock
+++ b/e2e/yarn.lock
@@ -2103,10 +2103,10 @@ fn-args@^4.0.0:
   resolved "https://registry.yarnpkg.com/fn-args/-/fn-args-4.0.0.tgz#2e912f7a74c5e9ef25060bd60127d6a8680237a5"
   integrity sha512-M9XSagc92ejQhi+7kjpFPAO59xKbGRsbOg/9dfwSj84DfzB0pj+Q81DVD1pKr084Xf2oICwUNI0pCvGORmD9zg==
 
-follow-redirects@^1.14.0:
-  version "1.15.1"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.1.tgz#0ca6a452306c9b276e4d3127483e29575e207ad5"
-  integrity sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==
+follow-redirects@1.15.4, follow-redirects@^1.14.0:
+  version "1.15.4"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.4.tgz#cdc7d308bf6493126b17ea2191ea0ccf3e535adf"
+  integrity sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==
 
 foreground-child@^2.0.0:
   version "2.0.0"

--- a/package.json
+++ b/package.json
@@ -210,7 +210,8 @@
     "d3-color": "3.1.0",
     "loader-utils": "2.0.4",
     "@babel/traverse": "7.23.2",
-    "postcss": "8.4.31"
+    "postcss": "8.4.31",
+    "follow-redirects": "1.15.4"
   },
   "nohoist": [
     "**/babel-preset-react-app/@babel/runtime"

--- a/src/components/NewTaxonomy/NewTaxonomy.tsx
+++ b/src/components/NewTaxonomy/NewTaxonomy.tsx
@@ -191,7 +191,7 @@ const NewTaxonomy = ({
       }}
       treeCheckStrictly
       showCheckedStrategy={TreeSelect.SHOW_ALL}
-      treeExpandAction="click"
+      treeExpandAction={false}
       dropdownMatchSelectWidth={dropdownWidth}
       placeholder={options.placeholder || 'Click to add...'}
       style={style}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7162,9 +7162,10 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.7.tgz#609f39207cb614b89d0765b477cb2d437fbf9787"
   integrity sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==
 
-follow-redirects@^1.0.0:
-  version "1.14.9"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.9.tgz#dd4ea157de7bfaf9ea9b3fbd85aa16951f78d8d7"
+follow-redirects@1.15.4, follow-redirects@^1.0.0:
+  version "1.15.4"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.4.tgz#cdc7d308bf6493126b17ea2191ea0ccf3e535adf"
+  integrity sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==
 
 for-each@^0.3.3:
   version "0.3.3"


### PR DESCRIPTION
updating dependency to address vulnerability 

### PR fulfills these requirements
- [ ] Tests for the changes have been added/updated
- [ ] Docs have been added/updated
- [ ] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance
