### PR TITLE
fix: LEAP-640: Don't save empty draft on View All

### DIFF
--- a/src/components/TopBar/Actions.js
+++ b/src/components/TopBar/Actions.js
@@ -15,7 +15,6 @@ export const Actions = ({ store }) => {
   const isViewAll = annotationStore.viewingAll;
 
   const onToggleVisibility = useCallback(() => {
-    !isViewAll && entity.saveDraftImmediatelyWithResults({ useToast: true });
     annotationStore.toggleViewingAllAnnotations();
   }, [annotationStore]);
 

--- a/src/components/TopBar/TopBar.js
+++ b/src/components/TopBar/TopBar.js
@@ -1,15 +1,17 @@
 import { observer } from 'mobx-react';
+
+import { IconViewAll, LsPlus } from '../../assets/icons';
+import { Button } from '../../common/Button/Button';
+import { Tooltip } from '../../common/Tooltip/Tooltip';
 import { Block, Elem } from '../../utils/bem';
+import { FF_DEV_3873, isFF } from '../../utils/feature-flags';
+import { AnnotationsCarousel } from '../AnnotationsCarousel/AnnotationsCarousel';
 import { DynamicPreannotationsToggle } from '../AnnotationTab/DynamicPreannotationsToggle';
 import { Actions } from './Actions';
 import { Annotations } from './Annotations';
 import { Controls } from './Controls';
 import { CurrentTask } from './CurrentTask';
-import { FF_DEV_3873, isFF } from '../../utils/feature-flags';
-import { Button } from '../../common/Button/Button';
-import { Tooltip } from '../../common/Tooltip/Tooltip';
-import { IconViewAll, LsPlus } from '../../assets/icons';
-import { AnnotationsCarousel } from '../AnnotationsCarousel/AnnotationsCarousel';
+
 import './TopBar.styl';
 
 export const TopBar = observer(({ store }) => {

--- a/src/components/TopBar/TopBar.js
+++ b/src/components/TopBar/TopBar.js
@@ -19,11 +19,6 @@ export const TopBar = observer(({ store }) => {
 
   const isViewAll = annotationStore?.viewingAll === true;
 
-  const toggleViewAll = () => {
-    !isViewAll && entity.saveDraftImmediatelyWithResults({ useToast: true });
-    annotationStore.toggleViewingAllAnnotations();
-  };
-
   return store ? (
     <Block name="topbar" mod={{ newLabelingUI: isFF(FF_DEV_3873) }}>
       {isFF(FF_DEV_3873) ? (
@@ -36,7 +31,7 @@ export const TopBar = observer(({ store }) => {
                 icon={<IconViewAll />}
                 type="text"
                 aria-label="View All"
-                onClick={toggleViewAll}
+                onClick={annotationStore.toggleViewingAllAnnotations}
                 primary={ isViewAll }
                 style={{
                   height: 36,

--- a/src/stores/Annotation/store.js
+++ b/src/stores/Annotation/store.js
@@ -50,13 +50,16 @@ const AnnotationStoreModel = types
     function toggleViewingAll() {
       if (self.viewingAllAnnotations || self.viewingAllPredictions) {
         if (self.selected) {
-          const comments = self.store.commentStore;
+          // const comments = self.store.commentStore;
 
-          if (comments.currentComment) {
-            // comment will save draft automatically
-            comments.commentFormSubmit();
-          } else if (self.selected.type === 'annotation') {
-            // save draft if there are changes waiting to be saved
+          // @todo current comment is an object and that was not a part of original fix
+          // @todo so leave it for later
+          // if (comments.currentComment) {
+          //   // comment will save draft automatically
+          //   comments.commentFormSubmit();
+          // } else
+          if (self.selected.type === 'annotation') {
+            // save draft if there are changes waiting to be saved — it's handled inside
             self.selected.saveDraftImmediately();
           }
 

--- a/src/stores/Annotation/store.js
+++ b/src/stores/Annotation/store.js
@@ -50,6 +50,16 @@ const AnnotationStoreModel = types
     function toggleViewingAll() {
       if (self.viewingAllAnnotations || self.viewingAllPredictions) {
         if (self.selected) {
+          const comments = self.store.commentStore;
+
+          if (comments.currentComment) {
+            // comment will save draft automatically
+            comments.commentFormSubmit();
+          } else if (self.selected.type === 'annotation') {
+            // save draft if there are changes waiting to be saved
+            self.selected.saveDraftImmediately();
+          }
+
           self.selected.unselectAll();
           self.selected.selected = false;
         }

--- a/src/stores/Annotation/store.js
+++ b/src/stores/Annotation/store.js
@@ -52,8 +52,8 @@ const AnnotationStoreModel = types
         if (self.selected) {
           // const comments = self.store.commentStore;
 
-          // @todo current comment is an object and that was not a part of original fix
-          // @todo so leave it for later
+          // @todo `currentComment` is an object and saving them was not a part of original fix
+          // @todo so I leave it for next fix coming soon
           // if (comments.currentComment) {
           //   // comment will save draft automatically
           //   comments.commentFormSubmit();


### PR DESCRIPTION
We should save draft when user clicks on View All, but we should save it only if there are changes made to annotation.

### PR fulfills these requirements
- [ ] Tests for the changes have been added/updated
- [ ] Docs have been added/updated
- [x] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance

### Describe the reason for change
Draft is created/updated **every** time user click on View All, even if that's fresh new task, if there are no changes, if draft was saved a second ago.

### What alternative approaches were there?
We could add checks for actual changes to `saveDraftImmediatelyWithResults()`, but the whole approach should be revisited. So current fix is a quick patch for the actual problem.
Also the main reason for draft not being saved is the check for `editable` in `saveDraft()` — at this moment View All is already displayed and all annotations are not editable. Most probably it will be enough just to rewrite this check to check for annotation explicitly.

### This change affects (describe how if yes)
- [ ] Performance
- [ ] Security
- [x] UX — toast about "Draft saved" disappeared but it was only introduced a month ago; we'll return it later

### Does this PR introduce a breaking change?
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [x] No
- [ ] Not sure (briefly explain the situation below)

### What level of testing was included in the change?
- [ ] e2e (codecept)
- [ ] integration (cypress)
- [ ] unit (jest)
