### PR TITLE
fix: LEAP-388: Simplify SVG data URL generation

### DIFF
--- a/src/utils/__tests__/canvas.test.js
+++ b/src/utils/__tests__/canvas.test.js
@@ -1,0 +1,52 @@
+/* global describe, test, expect */
+import Canvas from '../canvas';
+
+const svgs = {
+  simple: [
+    '\'data:image/svg+xml,',
+    '%3Csvg xmlns="http://www.w3.org/2000/svg" height="16" width="2"%3E',
+    '%3Ctext x="0" y="11" style="font-size: 9.5px; font-weight: bold; font-family: Monaco"%3E',
+    'Test Label',
+    '%3C/text%3E%3C/svg%3E\'',
+  ].join(''),
+  complex: [
+    '\'data:image/svg+xml,',
+    '%3Csvg xmlns="http://www.w3.org/2000/svg" height="16" width="2"%3E',
+    '%3Ctext x="0" y="11" style="font-size: 9.5px; font-weight: bold; font-family: Monaco"%3E',
+    'A&lt;/text%3E B',
+    '%3C/text%3E%3C/svg%3E\'',
+  ].join(''),
+  score: [
+    '\'data:image/svg+xml,',
+    '%3Csvg xmlns="http://www.w3.org/2000/svg" height="16" width="28"%3E',
+    '%3Crect x="0" y="0" rx="2" ry="2" width="24" height="14" style="fill:%237ca91f;opacity:0.5" /%3E',
+    '%3Ctext x="3" y="10" style="font-size: 8px; font-family: Monaco"%3E0.60%3C/text%3E',
+    '%3Ctext x="26" y="11" style="font-size: 9.5px; font-weight: bold; font-family: Monaco"%3E',
+    'Test Label',
+    '%3C/text%3E%3C/svg%3E\'',
+  ].join(''),
+  empty: [
+    '\'data:image/svg+xml,',
+    '%3Csvg xmlns="http://www.w3.org/2000/svg" height="16" width="0"%3E',
+    '%3C/svg%3E\'',
+  ].join(''),
+};
+
+describe('Helper function labelToSVG', () => {
+  test('Simple label', () => {
+    expect(Canvas.labelToSVG({ label: 'Test Label' })).toBe(svgs.simple);
+  });
+
+  test('Complex label', () => {
+    // labels will be already escaped
+    expect(Canvas.labelToSVG({ label: 'A&lt;/text>   B' })).toBe(svgs.complex);
+  });
+
+  test('With score', () => {
+    expect(Canvas.labelToSVG({ label: 'Test Label', score: 0.6 })).toBe(svgs.score);
+  });
+
+  test('No label & score', () => {
+    expect(Canvas.labelToSVG({})).toBe(svgs.empty);
+  });
+});

--- a/src/utils/canvas.js
+++ b/src/utils/canvas.js
@@ -366,49 +366,27 @@ function brushSizeCircle(size) {
   return canvas.toDataURL();
 }
 
+/**
+ * Given a string of SVG xml, encode it into a data URL
+ * @param {string} data SVG XML string to encode
+ * @returns {string} Data URL containing inline SVG already enclosed in quotes
+ */
 function encodeSVG(data) {
-  const externalQuotesValue = 'single';
-
-  function getQuotes() {
-    const double = '"';
-    const single = '\'';
-
-    return {
-      level1: externalQuotesValue === 'double' ? double : single,
-      level2: externalQuotesValue === 'double' ? single : double,
-    };
-  }
-
-  const quotes = getQuotes();
-
-  function addNameSpace(data) {
-    if (data.indexOf('http://www.w3.org/2000/svg') < 0) {
-      data = data.replace(/<svg/g, `<svg xmlns=${quotes.level2}http://www.w3.org/2000/svg${quotes.level2}`);
-    }
-
-    return data;
-  }
-
-  data = addNameSpace(data);
-  const symbols = /[\r\n%#()<>?[\\\]^`{|}]/g;
-
-  // Use single quotes instead of double to avoid encoding.
-  if (externalQuotesValue === 'double') {
-    data = data.replace(/"/g, '\'');
-  } else {
-    data = data.replace(/'/g, '"');
-  }
-
-  data = data.replace(/>\s{1,}</g, '><');
   data = data.replace(/\s{2,}/g, ' ');
 
-  // var resultCss = `background-image: url();`;
-
+  const symbols = /[\r\n%#()<>?[\\\]^`{|}]/g;
   const escaped = data.replace(symbols, encodeURIComponent);
 
-  return `${quotes.level1}data:image/svg+xml,${escaped}${quotes.level1}`;
+  return `'data:image/svg+xml,${escaped}'`;
 }
 
+/**
+ * Given a label and optional score, return an SVG data URL to use it in regions.
+ * Has internal caching to avoid recalculating the same SVGs.
+ * @param {string} label Label text
+ * @param {number} [score] Score in [0, 1] range
+ * @returns {string} Data URL containing inline SVG already enclosed in quotes
+ */
 const labelToSVG = (function() {
   const SVG_CACHE = {};
 
@@ -454,7 +432,8 @@ const labelToSVG = (function() {
       width = width + calculateTextWidth(label) + 2;
     }
 
-    const res = `<svg height="16" width="${width}">${items.join('')}</svg>`;
+    const xmlns = 'xmlns="http://www.w3.org/2000/svg"';
+    const res = `<svg ${xmlns} height="16" width="${width}">${items.join('')}</svg>`;
     const enc = encodeSVG(res);
 
     SVG_CACHE[cacheKey] = enc;


### PR DESCRIPTION
`encodeSVG()` is too complex for expected outcome, so it was simplified.
- No quotes management
- No namespace control (we build that SVG, so have full control already)
- No other unnecessary code we don't need, because SVG is generated by us
- Comments
- Simple unit tests for couple of cases

### PR fulfills these requirements
- [ ] Tests for the changes have been added/updated
- [ ] Docs have been added/updated
- [ ] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [ ] Self-reviewed and ran all changes on a local instance

### Describe the reason for change
https://github.com/HumanSignal/label-studio-frontend/security/code-scanning/10
Initial idea was to use SVG parser to parse+generate SVG again, but it turned out as a simplier problem

### What feature flags were used to cover this change?
None

### This change affects (describe how if yes)
- [ ] Performance
- [x] Security
- [ ] UX

### Does this PR introduce a breaking change?
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [x] No
- [ ] Not sure (briefly explain the situation below)

### What level of testing was included in the change?
- [ ] e2e (codecept)
- [ ] integration (cypress)
- [x] unit (jest)
